### PR TITLE
Add VISC_LATV dataset

### DIFF
--- a/lv-exams/NLG/VISC_LATV.json
+++ b/lv-exams/NLG/VISC_LATV.json
@@ -1,0 +1,2565 @@
+{
+"LV_EXAM_SET":[
+ {
+  "TEKSTA_FRAGMENTS": " Ticis Rīgā, zaķis uzmeklē sēklu tirgotavu. Ko tur daudz gudros, ies tik iekšā un\nprasīs kāpostu sēklas. Bet tirgotājs, visas sēklas pārdevis, pašlaik slauka kopā\npabiras.\n – Ko jaunskungs vēlas? – pa tirgotāju vīzei tas laipni noprasa.\n – Kāpostu sēklas, – zaķis bailīgi tikko dabū pār lūpu.\n – Kādu kāpostu sēklas jaunskungs vēlas: mums ir galviņu kāposti, rožu\nkāposti, kacenu kāposti. Varbūt jaunskungs ņems kacenu kāpostus – vasarā var\nēst lapas, ziemā grauzt kacenu?\n „Nu tas gan ir blēdis,” zaķis nodomāja. „Visādu kāpostu sēklas piesola, bet par\nvisgaršīgākajiem ne vārda.”\n– Un citādu kāpostu sēklu jums nav? – viņš viltīgi noprasa.\n– Nav, – pārdevējs noplātīja rokas.\n– Es gribētu skābu kāpostu sēklas, – jau drošāk uzstājās zaķis.\nTirgotājs pavīpsnāja – šis pircējs, acīm redzot, bija galīgi uz zaķa.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2008\/2009"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "– Ak skābu kāpostu, – pavisam saldā balsī iesaucās tirgotājs. – Jā, tās mēs\ndodam par velti. – Viņš saslaucīja sēklu pabiras maisiņā un pasniedza zaķim. –\nŠe, dēls, bāz kabatā. Ap Vasarsvētkiem iesēj, ap Jāņiem jau ēdīsi skābu skābos,\nZiemassvētkus nemaz negaidīsi!\nZaķis laimīgs brauca mājā. Ģimene iesēja kāpostus mitrajā meža liekņā. Zaķis\npats sēdēja klāt un uzmanīja, lai putni neizkasa, lai kurmji neizrok, lai kazas\nneapgrauž. Sieva tos ravēja no rīta līdz vakaram, bērni nesa ūdeni un laistīja\ndivreiz dienā. Tikai tad, kad trijlapainie kāposti sāka laisties baltos ziedos, zaķis\npirmoreiz nogaršoja jauno ražu.\n– Lai mani vilks apēd, ja tie nav skābi kāposti, – iesaucās zaķis, lēnām\nsūkādams nokosto lapiņu. Nu arī zaķene un zaķēni saklupa kāpostu grēdā un\nslavēdami ēda skābus kāpostus vasaras laikā.\nNu zaķis kļuva lepns un lielīgs kā tītars. Visus aicināja uz skābu kāpostu\nmielastu. Kopš tā laika skābās meža puķītes sauc par zaķa kāpostiem.\n",
+  "KLASE": 3,
+  "MACIBU_GADS": "2008\/2009"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Lauris iziet cauri nelielam krūmājam. Kājas sāk stigt miklajā zemē.\nViņš sāk lēkāt pa ciņiem, uz kuriem sārtojas dzērvenes. Tur aug nelieli,\nlīki bērziņi un retas priedītes. Bērni sēž krastmalā un vēro rāmo ūdens virsmu. Mazi vilnīši skrien uz\nkrastu. Visus priecē baltās ūdensrozes.  Juris stāv un skatās tālu pāri mežu galiem. Viņš redz tālumā\naizlokāmies līkumotos ceļus, saskata mājas – mazas kā sērkociņu\nkārbiņas.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2008\/2009"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Andra un Mārītes māmiņai bija lādīte ar saktām. Tās bija vienīgā piemiņa no Latvijas, ko viņa\npaņēma līdzi, dodoties trimdā. Bērni bieži vien pārcilāja saktas. Katra no tām bija citādāka – dažas bija\napaļas, cita atgādināja šaujamo stopu, vēl kāda izskatījās pēc pakava. Viena sakta bija darināta no\ndzintara, dažas bija misiņa un bronzas, bet vairums sudraba. Māmiņa apgalvoja, ka katra no tām\nsaistās ar kādu notikumu latviešu tautas dzīvē. Reiz kādā vakarā, kad pieaugušo nebija mājās, senās\nrotas bērniem atklāja savus stāstus un vēsturi. Lūk, kā tas notika.\nPacēlās lādītes vāks, un no tās izkāpa dzintara sakta. Lepni pagrozījusies, tā paziņoja: „Mēs,\nsaktas, esam sena tērpa sastāvdaļa, ko pazina jau 16. gs. p. m. ē. Mūsu vissenākā forma ir tērpa\nsaspraužamā adata. Vēlāk tā pārtop saktā, bet saglabā savu sākotnējo nozīmi. Ar saktām varēja\nsaspraust apģērbu, tās varēja izmantot arī jostu savienošanai. Mūsu pirmsākumi rodami novados ap\nAdrijas jūru. Es, dzintara ripas sakta, esmu cēlusies senajā Prūsijā. ",
+  "KLASE": 6,
+  "MACIBU_GADS": "2008\/2009",
+  "Column4": "                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   "
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Divtūkstoš gadus pirms Kristus\ndzimšanas viļņu izskalotos dzintara gabalus rotkaļi izveidoja saules rata formā, jo senprūši tajos laikos\npielūdza sauli. Gar manām malām iekala līkločus, bet vidū izkala caurumu.”\nPārējās saktas sarosījās: „Runā saprotamāk, mēs neprotam prūšu valodu! Un vispār tev nebūtu te\njāatrodas. Kāds tad tev sakars ar latviešiem?”\n„Prūši, latvieši un lietuvieši ir baltu tautas, tāpēc vēsture sākotnēji kopīga,” paskaidroja dzintara ripas\nsakta.\n„Varētu šķist, ka dzintara sakta bija vienīgā visā pasaulē! Nē, pirms 2 tūkstošiem gadu parādījāmies\nmēs, stopa saktas. Mūs valkāja kā vīrieši, tā sievietes. Laikā no 5. līdz 8. gadsimtam bijām iekarojušas\nvisu tagadējo Latvijas teritoriju. Mūs nēsāja vēl 11. gadsimtā.”\nTe ierunājās pakavsakta: „Mūsu cilts ir ļoti cienījama. Ilgā mūža dēļ varam nostāties blakus stopa\nsaktām. Mūs sāka kalt 8. gadu simtenī, bet par ziedu laiku uzskatām 10.–13. gadsimtu. Sākumā mūs\nvalkāja sievietes un vīrieši, vēlāk – tikai sievietes. Beidzamie mūsu cilts pārstāvji sastopami vēl\n17.gadsimtā.”\n",
+  "KLASE": 6,
+  "MACIBU_GADS": "2008\/2009"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "„Ko nu, ko nu! Ne jums abām mirdzuma, ne daiļuma. Paskatieties uz mani!” atskanēja sudraba\nsaktas balss. „Esmu jaunākā un arī pazīstamākā no jums.” No šīs saktas stāstītā bērni uzzināja, ka\n18.un 19. gadsimtā nav nevienas ģimenes, kurai nebūtu kādas sudraba saktiņas. Tās lieto gan kreklu,\ngan villaiņu saspraušanai. Kreklu saktas nēsājuši kā vīrieši, tā sievietes. Saktu valkāšana šajā laikā\nbijusi stingri noteikta: krekliem sprauda mazās, apaļās, bet villainēm sievietes izmantoja lielās, apaļās\nburbuļsaktas – uz apaļa pamata uzlikti astoņi vai desmit puslodei līdzīgi burbuļi.\nVisjaunākās saktas formas, kas parādās 19. gs., ir sirdsveida ar piekariņiem. Tās īpaši patika\nkurzemniecēm un zemgalietēm.\nŠajā vakarā Mārīte un Andris pirmo reizi dzirdēja arī vārdu kniepķens.\nKas tas ir? Dienvidkurzemes sakta, ko veido divas ar metāla stieplīti saistītas puslodītes.\nSavs stāsts bija arī lāča zoba saktai un četrstūra saktai. „Mēs esam latviešu karavīru saktas, kuras\nparādījās apģērbā 13. gadsimtā. Esam pavisam vienkāršas un domātas aizsardzībai, tāpēc ar īpašu\ngreznumu neizceļamies. Abas mūs rotā uzraksts AVE MARIA, kas nozīmē – Esi sveicināta, Marija,”\nskaidroja sakta ar piekārtu lāča ilkni. „Mans saimnieks ticēja, ka tā pasargāsies no nelaimēm.”\nDaudz interesanta varētu pastāstīt arī pārējās saktas, bet tas lai paliek citām reizēm. Latvijas\nvēsture nav vienā vakarā izstāstāma.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2008\/2009"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Tētis man jautāja Vai tu zini cik novadu veidoja Latviju pirmās brīvvalsts laikā\nZinu gan lepni atbildēju četri savstarpēji atšķirīgi kultūrvēsturiski novadi\nTu gan bērns esi gudrs tētis piebilda\nMani interesē Kurzemes vēsture, tāpēc varu par to pastāstīt.\nEs zinu, ka Kurzemes novadā ietilpst seno kuršu un lībiešu zemes – Bandava, Ventava,\nVanema, Piemare, Duvzare. Novada ziemeļos dzīvoja lībieši. 16. gadsimtā Kurzeme bija\nsaimnieciski attīstītākā Latvijas teritorijas daļa. Kurzemei bija cieši tirdznieciskie sakari ar\nārvalstīm. Tas pamanāms novada tautastērpu bagātīgajās rotās un košajos, savdabīgajos\nrakstos.\nLielas un bagātas bija arī Kurzemes zemnieku sētas.\nMūsdienās Kurzemē ir ievērojamākās Latvijas ostas – Ventspils un Liepāja.\nInteresanti ir šādi apskatāmie objekti: valtaiķu baznīca, kapsēdes dižakmens, pūsēnu\nkāpa bernātos, kas ir viena no augstākajām kāpām Latvijā, jaņa rozentāla muzejs saldū u.c. ",
+  "KLASE": 6,
+  "MACIBU_GADS": "2008\/2009"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Tētis man jautāja Vai tu zini kā vēl šodien sauc seno baltu cilšu apdzīvotās\nteritorijas\nZinu gan tēti jo skolā mums par to mācīja paskaidroju\nNovadi atšķiras cits no cita ar vēstures gaitu es turpināju saimniekošanas tradīcijām\nvalodas īpatnībām un tautas paražām\nMan patīk Vidzemes novads, tāpēc varu par to pastāstīt.\nVidzeme ir lielākais un gleznainākais Latvijas novads. Jau senatnē tajā ietilpa latgaļu\nzemes Tālava, Koknese, daļa Atzeles un Jersikas, kā arī lībiešu zemes Rīgas līča austrumu\npiekrastē. Seno latgaļu vēstures liecības glabā Lielvārdes, Kokneses, Turaidas un Krimuldas\npilsdrupas. Īpaši savdabīga ir Āraišu ezerpils.\nVidzemē atrodas Latvijas augstākie kalni, tur ir visvairāk nokrišņu, ilgāk saglabājas\nsniega sega.\nMūsdienās nozīmīgākās šī novada pilsētas ir Sigulda, Cēsis, Valmiera.\nVidzemē apskatāmi tādi objekti kā lauču dižakmens, jūrskolas muzejs ainažos,\nmazsalacas skaņaiskalns, rūdolfa blaumaņa muzejs ērgļos.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2008\/2009"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "1997. gada 14. novembri (Astridas Lindgrēnes 90. dzimšanas diena) zviedri izvērš par nacionālajiem svētkiem un ievēl rakstnieci par „Gada\npopulārāko zviedrieti” un par „Gadsimta iemīļotāko\nzviedrieti”. Televīzijas intervijā rakstniece nosmīkņā:\n„Tā vien šķiet, ka jūs kaut ko esat piemirsuši. Un, proti,\nesmu veca, kurla, pusakla un gandrīz jukusi. Un tādu\njūs titulējat par gada zviedrieti! Lūdzu, šo ziņu\nneizplatiet tālāk, citādi vēl padomās, ka visi zviedri ir\ntādi.”\n1996. gadā krievu zinātnieki lūdz atļauju\njaunatklātajam asteroīdam Nr. 3204 dot Astridas\nLindgrēnes vārdu. Rakstniece pasmejas, ka turpmāk\nviņu mierīgi var uzrunāt par Asteroīdu Lindgrēni.\nLiteratūras zvaigzne pārstāj rakstīt tikai akluma dēļ,\nviņas pēdējais darbs ir 1992. gadā iznākušais\nautobiogrāfiskais Ziemassvētku stāsts.\n1987. gadā savā 80. dzimšanas dienā Astrida\nLindgrēne sēž uz teātra skatuves ar ziedu vainadziņu\ngalvā un pieņem apsveikumus, bet mājās rakstnieci\ngaida sešpadsmit pasta maisi ar vēstulēm. Katru\nnedēļu rakstniece saņem 150 vēstules no bērniem.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2008\/2009"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Atbildēt mazajiem lasītājiem ir goda lieta. Taču viņa\nsaož arī skolotāju ietekmi. Un 1982. gadā uzraksta\natklātu vēstuli visiem Zviedrijas skolotājiem – „Ļaujiet\nman būt grāmatu, nevis vēstuļu rakstītājai!”. Lielo\nvēstuļu pieplūdumu var saprast, jo pirms tam – 1981.\ngadā – klajā nāk „Ronja – laupītāja meita”. 1978. gadā\nvācu grāmatizdevēji nolemj izcilajai zviedru rakstniecei\npiešķirt Miera prēmiju. Ceremonijas rīkotāji lūdz\nrakstnieci runāt par mieru un tikai par mieru.\nDrošības labad viņi tomēr vēlas iepazīties ar\nrakstnieces pateicības runu. „Nē – vardarbībai!” ir\ntas, ko viņi izlasa. Miera prēmijas laureāte savā runā\nsparīgi kritizē vardarbību pret bērniem un vardarbību\npasaulē, jo miers pasaulē būs tikai tad, ja pret bērniem\nizturēsies ar cieņu. Prēmijas devēji lūdz rakstnieci\nšādu runu neteikt. Astrida Lindgrēne atbild, ka tad\nviņa prēmiju nepieņems. Beigas ir labas – rakstniece\ndabū prēmiju, runas iedvesmots, Zviedrijas parlaments\nizdod likumu pret vecāku vardarbību. Viņas runu\nVācijas avīzes publicē lielos metienos. Un vācu bērni ir\nsajūsmā. Divi bez vecākiem palikuši brālīši steigā\ndodas uz Zviedriju pie rakstnieces, kura ir teikusi, ka\nbērnus nedrīkst sist. Bet tas ir tīrais sīkums\nsalīdzinājumā ar politiskajām debatēm, kurās Astrida\nLindgrēne iesaistās 1976. gadā. Maza priekšvēsture:\n70. gados Lindgrēnes grāmatas un filmas bija laba\nZviedrijas eksportprece",
+  "KLASE": 9,
+  "MACIBU_GADS": "2008\/2009"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "To autore saņēma lielus\nhonorārus un nekurnēdama maksāja nodokļus. Bet\ntad sociāldemokrātu valdība nolemj, ka\npašnodarbinātajiem, kādi ir arī rakstnieki, nodokļos\njāmaksā vairāk, nekā viņi nopelna. Astrida Lindgrēne\nuzsāk cīņu. Kāds tad ir viņas ierocis? Protams,\npasaka. Viņa uzraksta „Pomperiposa Monismānijas\nzemē”. Sociāldemokrāte Lindgrēne aicina vairs\nnebalsot par valdošo sociāldemokrātisko partiju, tā\nteikt, lai atpūšas no saindēšanās ar varu. Viņas\npasaku par nodokļiem vēlēšanu kampaņā izmanto\nliberālā tautas partija. Un tik tiešām sociāldemokrātu\nvaldība (pēc 40 gadiem varas) tolaik Ulofa Palmes\nvadībā krīt.\n1974. gadā Zviedrijas televīzija pārraida, kā\n67 gadus vecā Astrida Lindgrēne un viņas\ndraudzene Elsa Ulēniusa, kurai todien aprit\nastoņdesmit, rīko sacensības kokā kāpšanā. Tā sakot – „nekādu aizliegumu vecām sievām rāpties\nkokos”. Togad nomirst rakstnieces brālis Gunnars. Vai\nto, kāds neaizpildāms tukšums rodas pēc brāļa\nnāves, var nojaust gadu iepriekš, rakstot „Brāļus\nLauvassirdis”?",
+  "KLASE": 9,
+  "MACIBU_GADS": "2008\/2009"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "1973. gadā „Brāļi Lauvassirdis” dodas\npie lasītājiem. Tolaik Lindgrēnei ir 66 gadi. „Brāļi\nLauvassirdis” izraisa debates zviedru parlamentā.\nPolitiķiem šķiet, ka grāmata cildina pašnāvības tēmu.\nLindgrēne pati bija biedrībā „Tiesības uz mūsu pašu\nnāvi”, kas aizstāvēja tiesības nomirt ar godu, lai\nsavai nedziedināmajai slimībai vai bezjēdzīgajām\nciešanām cilvēks pats varētu pielikt punktu.\nGrāmatu nežēlīgi kritizē arī ārpus parlamenta – rakstīt par nāvi kā problēmas atrisinājumu bērnu\ngrāmatā esot ne vien bezatbildīgi, bet pat šausmīgi.\nKādā seminārā jauns psihologs teic, ka grāmatas\nnoslēguma rindiņas viņš nekad nespētu lasīt bērnam\npriekšā. Jo brāļiem jāmirst divas reizes. Tad Astrida\nLindgrēne atbild: „Tas ir tā – jo biežāk jāmirst, jo\nvairāk pie tā pierod.” Tajā pašā vakarā rakstniecei\npiezvana meitene, kura zviedru filmā par Emīla\nnedarbiem spēlē Idu. Viņa ir izlasījusi „Brāļus\nLauvassirdis” un pateicas rakstniecei par tik laimīgu\ngrāmatas nobeigumu. Astrida Lindgrēne priecājas,\nka bērni viņas vēsti ir sapratuši. Interesanti, kā\nrakstniecei iešāvās prātā brāļu Lauvassiržu ideja?\nIzrādās – lēnām krājot izjūtas. ",
+  "KLASE": 9,
+  "MACIBU_GADS": "2008\/2009"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Viņai allaž paticis klīst pa kapiņiem. Reiz Vimmerbijas kapsētā uz kāda kapakmens izlasījusi: „Šeit atdusas brāļi Fāleni,\nmiruši jauni 1860...” Pēkšņi sapratusi, ka nākamā\ngrāmata būs par nāvi un par šiem diviem mazajiem\nbrāļiem. Kas ar viņiem noticis, ko viņi piedzīvojuši? Otrs\nvērojums: kad filmai meklēts Emīla lomas atveidotājs,\nprese sacēlusi tādu ažiotāžu, it kā būtu jāizraugās\nRomas pāvests. Preses konferencē mazais Janne\nuzcelts uz galda. Fotogrāfi klikšķina, žurnālisti izjautā.\nJanne mierīgi stāv un atbild. Kad viss ir galā, nolec\nno galda un iesēžas klēpī savam septiņus gadus\nvecākajam brālim. Lielais brālis Janni apkampj un\nnobučo uz vaiga. Rakstniece nodomā, lūk – tie te ir\nmīļi brāļi. Viņa vēl nezina, kāpēc brāļi viņai vajadzīgi un\nko viņi darīs. Bet tad viņa Vermlandē 1970.\/1971.\ngadu mijā brauc ar mazbānīti gar ezeru. Debesis ir\nfantastiskās krāsās, ir tik brīnišķīgs ziemas rīts, tik\nskaists, vairs ne no šīs pasaules. Un viņa nodomā,\nka brāļi Lauvassirdis vairs nav uz zemes... tā rodas\ndoma par Nangijālu.\nEksāmens latviešu valodā 9. klasei Tekstu lapa 2009. gada 26. maijā 2\nISEC Vaļņu ielā 2, Rīgā, LV-1050\n1969. gadā nomirst rakstnieces tēvs, māte jau\nagrāk – 1961. gadā.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2008\/2009"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Lindgrēne apkopo tēva un mātes\nmīlestības vēstules, ko viņi bija saudzīgi glabājuši,\nun uzraksta stāstu par vecākiem.\n1965. gadā rakstniece saņem Zviedrijas valdības\nprēmiju literatūrā. Ko viņa dara ar naudu? Tūlīt iegūst\nīpašumā savu vecāku māju „Nēsas”, kur pati ir dzimusi,\natjauno un iekārto to tā, kā atceras no savas bērnības.\nPirmā grāmatiņa, ko trīsgadīgā Astrida saņem,\nir Ziemassvētku kalendārs bērniem 1911. gadam ar\nSniegbaltīti uz vāka – melniem matiem, sarkanu mici\ngalvā. Astrīdai tā šķiet brīnumskaista. Un, kad grāmata\npaveras, iekšā ir brīnumaini stāsti. Kā pasakā dzīvoja\narī Astridas vecāki. Viņi mīlēja viens otru kopš\nbērnības – visu mūžu. Kad trīspadsmitgadīgais\nSāmuels Augusts Eriksons ierauga deviņus gadus\nveco Hannu Junsoni, viņš acumirklī iemīlas. Pēc\nseptiņpadsmit gadiem abi apprecas. Sāmuels Augusts\nir zemnieks, Hanna – mājsaimniece, kaut labprātāk\nbūtu skolotāja. Viņi rentē senu mācītājmāju „Nēsās”\npie mazpilsētas Vimmerbijas. Gadu pēc kāzām\npiedzimst dēls Gunnars, un vēl pēc gada, 1907. gada\n14. novembrī, Astrida Anna Emīlija Eriksone\nierauga šīs pasaules gaismu. Tik spožu! Un sāk\nspēlēties. ",
+  "KLASE": 9,
+  "MACIBU_GADS": "2008\/2009"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Ir rakstnieki, kuru uzrakstīto var lasīt, neaizķeroties\nne aiz viena vārda, visi pazīstami un zināmi. Un ir\nciti, kuru darbos ik pa brīdim aizķeries aiz kāda\nvārda kā aiz kukuržņa. Šie vārdu kukuržņi palīdz\napstāties un palūkoties vērīgāk, par ko īsti ir runa.\nL. Muktupāvelas un A.Terzena kopīgi sarakstītajā\ngrāmatā „Tas notiek Latvijā” (2006) no aizmirstības\nizcelts vārds „čuinis” — cilvēks, kas runā svešā izloksnē\nvai valodā. Mūsdienās arvien mazāk saglabājas\nčuiņu un čuinismu. Valoda palikusi līdzenāka,\ngludāka un iepriekšparedzamāka. Taču pietiek atvērt\nkādu no klasikas darbiem, kā čuinismi lien ārā līdz ar\nvisām savām mazajām, bet saistošajām „biogrāfijām”.\nĻoti daudz čuinismu Kurzemes, Latgales rakstnieku\ndarbos. Taču tādu daudz arī Sēlijas rakstnieku Jāņa\nVeseļa, Lūcijas Ķuzānes, bet jo īpaši Jāņa\nJaunsudrabiņa darbos. Nesen iznāca pārlasīt\nJaunsudrabiņa „Balto grāmatu”, padevos apgāda\n„Valters un Rapa” skaisto balto vāku kārdinājumam. ",
+  "KLASE": 9,
+  "MACIBU_GADS": "2008\/2009"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Pati brīnījos, kā bērnībā esmu tikusi garām nesaprotamo vārdu kukuržņiem un kā tiem garām tiek\nmūsdienu skolās, bet simt tēlojumos ir pāri par\npiecdesmit vārdu, kuru nozīme zudusi vai ir tikai no\nteikuma kopjēgas nojaušama: ģelbt – glābt:\n„Izstiepās gar sienu, čukstēdama, lai Dieva dēļ\nšo paģelbjot.” (235. lpp.); knasts — pieguļošs;\nsmalks, gaumīgs: „Tur kungus no muguras puses\nnemaz nevarot atšķirt no dāmām, tik knasti viņi\nģērbjoties.” (174); kraitāt — zvāroties, grīļoties,\nstreipuļot: „Beidzot jau mēs kraitājām vien un runājām\ndažādas muļķības.” (197); lumstīties — luncināties;\nparādīt kādam īpašu laipnību, robežojoties ar iztapību; būt tiešā tuvumā: „Suņi māti pazina un sāka\nlumstīties.” (230); nagot — steigties: „Vīrs (..) nagojis uz\nsētu neatskatīdamies.” (54). Šis vārds, kā šķiet,\nsaistāms ar izteicieniem, kuri vairāk vai mazāk\nsaglabājušies mūsu apziņā, piemēram, „Šinīs lietās\nviņam ir nags”, t.i., te pamatā vārda „nags” pārnestās\nnozīmes: spēks un veiklība, izmanība („nadzīgs”). Ja\nnosauktos vārdus vēl kaut kā var atpazīt, tad\nJaunsudrabiņa „Baltajā grāmatā” ir ja ne papilnam,\ntad pietiekami vārdu, kuru nozīmes bez īpašas\n„izmeklēšanas” pavisam neskaidras: obaža —\nnelaime, liksta: „Redzi nu. Un nebūtu klausījies, būtu\natkal piesitusies kāda obaža.” ",
+  "KLASE": 9,
+  "MACIBU_GADS": "2008\/2009"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Vārdu un piemēru skaitu var brīvi papildināt, bet\npamatjautājums cits. Kurā virzienā iet mūsu valodas\nkuģis? Mēs, protams, varam iztikt bez vābīšanas,\nurlāšanas, nebūs liela obaža. Diez vai ieviesīsim\nikdienas vārdkrājumā tādus vārdus kā irināt\n(„Klausījies zemes vēzīša irināšanā.”, 442), jo nav\nvairs kam irināt, visus zemes vēzīšus, iespējams,\nesam iznīcinājuši, vai arī bābiņa — skalturis. Runa ir\npar citu — varam iztikt (kā krievu klasiķu Ilfa un\nPetrova romāna „Divpadsmit krēsli” varone Elločka)\nar 30 vārdiem, bet varam tiekties arī uz Šekspīra 12\n000 vārdu krājumu. Ja uz otro, tad nebūtu par sliktu\nizdot Jāni Jaunsudrabiņu u.c. mūsu klasiķu darbus\nne tikai uz laba papīra un lieliskos vākos, bet arī ar\npiemirsto vārdu skaidrojumu.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2008\/2009"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Neviens nezina, kāda pasaule būs pēc pieciem gadiem, jo izmaiņas, kuras kādreiz notika 1000 gadu laikā, tagad norisinās pusgadā. Sabiedrība kļuvusi plastiskāka, gan ekonomikas likumi elastīgāki, arī veids, kā mēs sazināmies, mainās zibenīgi. Es gribētu teikt, ka Latvija sava de jure statusā pastāvēs pilnīgi noteikti. Latvijā dzīvos labāki cilvēki, kurus virzīs\nvērtības, nevis intereses. Atbildība par savu rīcību sabiedrības priekšā. Nedari otram to, ko negribi, lai dara tev. Tiekšanās pēc vērtībām vienmēr veicina lielāku labklājību nekā tiekšanās pēc paša\nlabklājības. Piemēram, Dānijā cilvēki atbild ne vien par savu, bet arī par savu apkārtējo rīcību. Šodien mēs audzinām bērnus pēc principa – kļūdīties ir sliktākais, ko mazais var izdarīt. Tā mēs viņus mērķtiecīgi apslāpējam. Laimīgas Latvijas nākotnes garantija – audzināt radošu paaudzi. Bērnus, kuri domā, nevis atkārto. Bērnus, kuri nāk klajā ar idejām, nevis izpilda priekšrakstus.  Nedomāju, ka ar likumu var pavēlēt, kādam jābūt radošam cilvēkam, bet sabiedrībā jau ir tāds darvinisms kā dabā. ",
+  "KLASE": 12,
+  "MACIBU_GADS": "2008\/2009"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Ja tu redzi, ka jaunajā laikmetā vairāk sasniedz tie, kas\nmēģina, kļūdās, ceļas, atkal mēģina, un nevis tie, kas vienkārši izpilda priekšrakstus, tad, iespējams,\nvairāk cilvēku mēģinās saviem bērniem mācīt domāt. Latvieši ir izcili apķērīgi, ārkārtīgi talantīga tauta ar diviem trūkumiem. Pirmkārt,\npašironijas trūkums. Tas liedz mums tvert lietas viegli, mums visu laiku liekas, ka mūs mēģina aizvainot\nvai nodarīt pāri. Otrkārt, latvieši neprot būt paši. Viņi reizēm ir mazliet ciniski romantiķi vai nihilistiski\nideālisti. Latvieši parasti atstāj atkāpšanās ceļu.  Pamazām, ar uzslavām. Es latviešiem nemēģinātu iestāstīt, cik mēs esam labi,\nvareni. Es sameklētu ārvalstu ekspertus, kas no savām pozīcijām uzrakstītu, cik latvieši ir fantastiski.\nDiemžēl mēs ticam tikai citiem, bet neticam sev. Latviešiem šķiet, ka mums kaut kas automātiski pienākas. Ja mūsu vajadzības netiek apmierinātas, mēs meklējam vainīgo, nevis novērtējam reālo situāciju.\n",
+  "KLASE": 12,
+  "MACIBU_GADS": "2008\/2009"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Lelde dzird jau pirmo aicinājumu, taču nevar uzreiz ar kājām pagaldē uztaustīt apavus, un, kad\nsauciens atskan pa otram lāgam, viņa pieliecas un ar rokām čamda pa galda apakšu, grābstīdamās kā\nakla uz labu laimi ar itin kā stīvi nosalušiem pirkstiem, jo tēva balss dzedrais tonis viņu reizē steidzina\nun stindzina. Viņa cenšas kustēties ātri, bet pinas kā pa miegiem, gan apzinādamās, ka šī kavēšanās\ntēvu tikai sadusmo, vēl vairāk – sanikno ar katru novilcinātu sekundi, taču nespēdama neko ar sevi\npadarīt. Pazīstamie lokanie un vijīgie locekļi – kājas, rokas – gluži kā nepieder viņai, un sirds pukst\nnevis tur, kur parasti, bet kaut kur augstāk, kaklā, rīklē, un viņa lūko to norīt kā iesprūdušu kumosu.\nTā, beidzot čības rokā. Viņa uzauj tās un tuvojas durvīm, saspringusi kā sitiena gaidās. Viņa visu\nlaiku zināja, ka pienāks šis brīdis, augu dienu apzināti un neapzināti viņa gaidīja to un baidījās no tā, un\npūlējās to novilcināt, aizbīdot sazin kur nākotnē, kur tam vajadzēja izšķīst laika nenoteiktībā. Viņa tika\ntam gatavojusies, bet nevarēja iedomāties, cik lielas īstenībā būs izbailes, kas viņu pārņems šajā\nacumirklī, it kā tuvojoties moku solam, šīs gandrīz vai baismas, kuras tagad uznirušas no aizmirstības,\natvedinot to briesmīgo, ko viņa visu dienu pūlējās un nevarēja atcerēties un ko bija baigi atcerēties, bet\nko atsaukt prātā sazin kāpēc šķita ļoti būtiski un svarīgi.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2008\/2009"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Un nu tagad, tuvojoties durvīm, aiz kurām gaida tēvs, pašā nepiemērotākajā brīdī no visiem, kādu\nvien var iztēloties, kad jāsakopo domas un spēki gaidāmajai sarunai, šajā visneatbilstošākajā mirklī viņa\nnegaidot atminas to – savu pagājušās nakts sapni – un viscaur nervozi nodreb no šīs atceres. Viņa\npēkšņi atkal uztver gandrīz izgaisušo murgaino vīziju aprises, kas šķietami uz laiku laikiem un uz\nneatgriešanos bija iegrimušas pagājībā, bet nu atkal ceļas augšup, rēgaini uzpeldot no zemapziņas.\n– Lelde, nu, kas tad ir? – viņu sasniedz jauns, jau pavisam nepacietīgs uzsauciens. – Tu nāksi vai\nnenāksi?\nJā, – viņa nespodri atbild, lūkodama saņemties un domāt par ko citu, izdzēst šo ainu un pievērsties\nkam citam, it kā šaušalas, ko viņa izjūt atceroties, būtu ierakstītas viņas sejā un, strāvojot no viņas kā\nplūsma, ar šausminošo atklāsmi spētu apņemt arī tēvu.\nBeidzot viņa ieiet, un pirmais skatiens krīt uz pašas lietām tēva rokās, un sejā spēji iesitas asinis, un\npietvīkums izplūst pa to kvēli un kaistoši no kleitas apkakles līdz matu ielokam. Leldi satriec mantu\natkailinātā intimitāte, kas, izvilkta no kabatas tumsas un aizsega atklātībā un gaismā izlikta vispārējai\naplūkošanai uz divām platām, divām lielām delnām, šķiet apkaunojoša un nožēlojama. Mutauti izskatās\nsaburzīti un neliekas pārāk tīri, un īriss ir patiešām briesmīgs, aizmirsts kabatas stūrī, apvazāts,\nsavārtījies un nospūris, kā sūkāts ar visu papīrīti un pēc tam atlikts atpakaļ. Un nu šīs lietas atsegušās\nar tādu izaicinošu nekaunību kā no vēdera dobuma izņemtas iekšas, šausminot ar savu derdzīgumu,\nkuru viņa tā pa īstam līdz šim nemaz neapzinājās.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2008\/2009"
+ },
+ {
+  "TEKSTA_FRAGMENTS": " Nu, kā tu to izskaidro? – vaicā tēvs. – Tu taču neapgalvosi, ka tas ielikts kabatā slepeni, bez tavas\nziņas un vienīgi aiz pārpratuma nomaskēts ar piešņauktiem mutautiem?\nAk, patiešām! Tēvs taču runā par cigaretēm, par to paciņu, ko viņa šodien nopirkusi un aizmirsusi\nkabatā un kas tagad gluda, spoža un neskarta – pati lepnākā un cēlākā no viņas mantām – spīdina\ngludo, bālgano, ar celofānu pārvilkto sānu.\nJā, – viņa ātri teic, nedomādama par to, ko saka.\nKas «jā»? Tātad aiz pārpratuma?\nN-nē, – viņa aprauti saka.\nNu, «jā» vai «nē»?\nViņa skatās tēva sejā, atkal pavisam nelaikā ar lielu skaidrību to atvedinot atmiņā tādu, kāda tā\nizskatījās sapnī.\nNē! – viņa strauji atkārto, pussolīti atkāpdamās, un viņas lūpas krampjaini savelkas.\nLabi, tad iesim tālāk.\nBrīdi viņi abi klusē, šķietami gaidot, kurš turpinās, it kā runāt negribētos ne vienam, ne otram.\nBeidzot atkal ieteicas tēvs:\n– Vakar tu viltoji zīmi fizkultūras stundai, samērā prasmīgi, atklāti sakot, pat pārsteidzoši lietpratīgi,\njādomā, ne bez cītīgiem treniņiem atdarinājusi manu parakstu... – Viņš no jauna apklust, iespējams,\nA\nEksāmens latviešu valodā un literatūrā 12. klasei Tekstu lapas 3. daļa 2009. gada 1. jūnijā 2\nISEC Vaļņu ielā 2, Rīgā, LV-1050\ntagad gaidot no Leldes paskaidrojumus vai iebildumus, vai kādus novēlotus atvainošanās vārdus, bet,\nkad nekas tā arī neseko, atkal, mazu brīdi vilcinājies, turpina: – Šodien tu pārnes cigaretes. Un rīt?...\nVarbūt rīt tu pārradīsies jau ar pus-stopu, ko? – viņš piebilst, uzsvērti sadalot un saskaldot šo vārdu –\nvārdu «pusstops», itin kā izspļaujot katru balsienu.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2008\/2009"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Lelde nesaka neko.\nNu? – tēvs paskubina.\nNē, – viņa vēlreiz nenoteikti nomurmina.\nKas atkal par «nē»?\nTaču Lelde nezin kāpēc netiek prom no šiem diviem īsajiem, strupajiem vārdiem, šiem «jā» un «nē»,\nitin kā tie būtu buramvārdi, kas spēj pasargāt no ļaunas mēles un ļaunas acs. Ir redzams un manāms,\ncik stipri tie tēvu kaitina un cik strauji rūgst tēva nepacietība, bet viņa neko nespēj padarīt. Viņa sajūt, ka\ntūlīt, tūlīt tas nenovaldīsies un atkal tāpat kā vakar grūšus izgrudīs ko tādu... tādu... ka vārds noplīkšķēs\nkā pļauka vai kā spļāviens. «Pag, ko viņš sacīja vakar?» Lelde domā, lai gan labāk būtu to\nneatminēties. «Tāds dīvains... tāds svešāds – kā cilvēka, kā dzīvnieka apzīmējums.»\nAbpus tēva mutei saspringst muskuļi, savilkdami lūpas plānā, taisnā švīkā, un vaibsti kļūst asi un\ndeguns smails, un āda nobāl līdz dzeltenīgam ziloņkaula tonim, uzreiz pārvēršot visu seju un darot to\nļoti saltu.\nTabačniece tāda! – beidzot tēvs izgrūž caur sakostiem zobiem. – Pīpmanīša! – tas saka ar\naizturētām dusmām un atklātām nievām un raugās lejup uz viņu kā uz kaut ko netīru un pretīgu, kā uz\nkaut ko samītu un uzšķērstu, kā uz kaut ko pūstošu un smirdīgu, no kā nelabumā aizraujas elpa un\nšķebīgumā trīc nāsis. Neviens kliedziens un nekādas lamas nevar mēroties nicinājumā un izsmieklā ar\nšo dziļa riebuma pilno skatienu, ar kādu tēvs lūkojas uz viņu no sava lielā stāva un nesatricināmās\ntaisnības augstumiem, un, prasot un pieprasot no viņas paskaidrojumus un atbildes, tas vienlaikus ar\nkatru kustību un katru vaibstu, ar visu būtību apliecina, ka netic nekam un ka neticēs itin gluži nekam, lai\nko viņa arī teiktu, jau iepriekš noraidot viņas taisnību un pat domās nepieļaujot viņas taisnības esamību\nun iespējamību. ",
+  "KLASE": 12,
+  "MACIBU_GADS": "2008\/2009"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Tēvs gaida tikai vienu: pakļaušanos, nožēlu, atvainošanos. Tēva rokās ir lietiskie\npierādījumi, salīdzinājumā ar tiem Leldes rīcības neskaidri apjaušamie un vēl vājāk pamatojamie cēloņi\nir tik nepārliecinoši un naivi, tik smieklīgi un nožēlojami... Tēva pusē ir dzelžainā loģika un fiziskā spēka\nacīm redzams pārsvars, un tas dzen Leldi sprostā, slazdā, lamatās, lauž transam līdzīgo stingumu, un\npēkšņi viņa iekliedzas spalgā, aizlauztā zaķa balsī:\nUn tu? Tu? Tu lien manā somā... un izokšķerē manas kabatas! Tu...\nTā, gatavs, nu arī tēvs sāks kliegt, tagad beidzot neizturēs un sāks kliegt, taču tas tikai iesmejas –\nnicinoši un auksti.\nĻoti jauki, ka pēc vakardienas notikumiem tevi vismaz sākusi interesēt šādu un tamlīdzīgu parādību\nētiskā puse, ko līdz šim diemžēl nevarēja manīt. Kaut vai spriežot pēc tavām fiktīvajām fizkultūras\nzīmēm. – Viņa izdara instinktīvu atvairošu un noliedzošu kustību, taču tēvs nemainīgi turpina: – Tikai, kā\nšķiet, tu pārprati mūsu attiecību raksturu. Nevis tu esi manējais, bet es esmu tavs tēvs, un nevis tev par\nmani, bet man jāatbild par tevi – morāli un juridiski.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2008\/2009"
+ },
+ {
+  "TEKSTA_FRAGMENTS": " Un tik ilgi, kamēr manos pienākumos ietilps šī\natbildība, es katrreiz izvēlēšos arī rīcības metodes. Neprasot nevienam atļauju, mīļā sirds, un ne ar\nvienu nesaskaņojot savus ieskatus. Tātad lūdzu to iegaumēt. Un vispār... Vāc prom, riebjas skatīties! –\ntēvs piepeši skarbi izgrūž, krasi mainot toni, kā kad pašam dergtos un vairs nebūtu paciešams un\nizturams vārdu nesteidzīgais, rāmi vēsais plūdums, un, paturot sev tikai cigaretes, sviešus nosviež uz\nkrēsla Leldes mantas, tā ka īriss nopakšķ uz grīdas un paveļas zem sēdekļa. – Un nākamajā reizē es\nbūšu spiests spert radikālus soļus. Tā ka liec aiz auss! Nu, vāc, vāc projām! Ļuļķētāja!\nNelūkodamās tēvā, Lelde sāk lasīt kopā savas lietas...",
+  "KLASE": 12,
+  "MACIBU_GADS": "2008\/2009"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Brūnais lācis pēc savas gaitas ir pēdminis. Vairums dzīvnieku ejot skar\nzemi tikai ar pēdas priekšējo daļu, tas ir, pirkstiem. Lāča pēda pēc formas un\nlieluma līdzīga cilvēka pēdai.\nPētnieki taigā novērojuši, ka lāči ir ļoti ziņkārīgi dzīvnieki. Iznākuši no\nsaviem biezokņiem, tie pa gabalu ne reizi vien skatījušies, ko dara cilvēki.\nTad atkal lēnām aizčāpojuši. Reiz brūnais lācis piegājis klāt mazai meitenītei,\nkas lasījusi brūklenes, apostījis viņu un tikpat mierīgi atkal aizgājis projām.\nMiga lācim mēdz būt dažādās vietās – zem kritušu koku stumbriem, to\nzarotnē, žagaru kaudzē, bieži vien arī kuplā eglīšu jaunaudzē.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2009\/2010"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Te sniega un\nzaru mājoklī janvārī vai februārī piedzimst mazie lācēni. Dažus mēnešus tie\npavada kopā ar māti ik minūti, jo tā no migas nemaz neiziet.\nPavasarī, marta otrajā pusē, lāči savas migas atstāj un tūlīt dodas uz\nsūnu purvu dzērvenēs. Iebaudījis ogas, lācis dodas uz upmalu, kur pavasara\nūdeņi malā izskalojuši ziemā nobeigušās zivis. Līdz ar putniem, mežacūkām\nun citiem zvēriem lācis novāc arī sniegā iesalušo dzīvnieku atliekas. Tāpat\nmielojas ar jaunajiem dzinumiem un zālaugu stiebriem. Bet vasarā, kā jau tas\nzināms, lācis labprāt mielojas ar medu.\nBrūnais lācis, kaut pēc izskata smagnējs un lēns, skrienot var sasniegt\nātrumu 60 kilometri stundā, veikli rāpjas kokā un peld. Dzīvo 30–50 gadu.\nSalīdzinot ar citiem dzīvniekiem, tas nav ne pārāk daudz, ne pārāk maz.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2009\/2010"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Kas var pārspēt kaķi peļu ķeršanā? Vai zini? Pavisam mazs zvēriņš – pats sīkākais plēsējs\npasaulē – zebiekste. Viņas ķermeņa garums ir apmēram 25 cm, turklāt astes garums 5–7 cm, bet\nsvars – 75–130 g.\nZebiekste ir ārkārtīgi straujš un kustīgs zvēriņš. Slaidā, lokanā ķermeņa dēļ zebiekste spēj iespraukties\npat peļu alās. Kājas tai samērā īsas.\nZebiekstes tērps ir gluds, mīksts un silts. To veido divējādi mati. Akotmati nosedz ķermeni un\nnosaka apmatojuma krāsu, pūku mati saglabā siltumu. Gludais apmatojums mugurpusē ir brūngans, bet\nvēderpusē – balts. Rudenī zebiekste brūno tērpu nomaina pret gaišāku un ziemā ir balta. Pavasarī zvēriņš\natkal „uzvelk” brūngano vasaras tērpu.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2009\/2010"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Zebiekstes galvenā barība ir peles un strupastes. Viņa medī galvenokārt rīta un vakara stundās.\nParasti dzīvo mežmalās, krūmājos, ganībās, gravās, ļoti reti – cilvēku mītņu tuvumā.\nSavu migu zebiekste pa lielākai daļai iekārto peļu alās. Turklāt šī miga izklāta ar „zvērādām” – ar\npeļu un citu peļveidīgo grauzēju vilnu. Maijā zebiekstei piedzimst mazuļi – 3–7 brāļi un māsas, retu reizi\nvairāk – līdz pat 12. Zebiekstes mūža ilgums ir 4–7 gadi. Interesanti, ka tajos gados, kad ir ļoti daudz peļu,\ndzimst arī vairāk zebiekšu, bet, kad peļu mazāk, arī zebiekstēm migās pēcnācēju mazāk.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2009\/2010"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Meitenes mūs apsveica Valentīna dienā, un mums vajadzēja to atlīdzināt.\nBeidzot vienojāmies, ka ar pieciem atbildīgajiem pilnīgi pietiek. Laimīgo skaitā bija\nEdžus, Valdis, Zigis, Jancis un es.\n– Nav ko stiept gumiju! Jāsadala uzdevumi, – ierosināja Zigis.\n– Kas mums vajadzīgs? Pirmām kārtām ziedi. Kurš apņemas sagādāt ziedus?\nNeviens neatsaucās.\n– Ja brīvprātīgo nav, vajadzēs lozēt.\n– Kur tad tu ziemas salā rausi puķes! – burkšķēja Valdis.\n– Manai mammai draudzene strādā dārzniecībā, – es izgrūdu.\n– Pa pirmo! – iesaucās Zigis. – Tā arī pierakstīsim.\nUz lapas viņš atzīmēja manu vārdu.\n– Kādas puķes tagad var dabūt? – vēl joprojām šaubījās Valdis. – Ja nu vienīgi\npirmās tulpes. Bet tās taču sasodīti dārgas. Kur mēs rausim tik daudz naudas?\n– Droši vien ir arī acālijas, – mierināja Zigis.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2009\/2010"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Kādas tās izskatās? – es nobijies prasīju.\n– Gan tevi iepazīstinās! Ja mēs pie viena punkta tik ilgi kavēsimies, līdz pusnaktij\ngalā netiksim. Domājam tālāk! Kas gatavos apsveikuma runu?\n– Jancis. Viņš ir vislabākais klases orators.\n– Jā, jā, stundā viņš vienmēr kaut ko muld, – ironizēja Edžus, bet Zigis viņā\nneklausījās un ierakstīja Janča vārdu zem manējā.\n– Kurš rūpēsies par galdu?\n– Te vajag divus, – sacīja Valdis, apsēzdamies skolotājas vietā pie galda. – Viens\ngādās torti, otrs – kaut ko stiprāku.\n– Neko stiprāku...\n– Es domāju – kādu krietnāku uzkožamo.\n– Tu pats, Valdiņ, esi palicis bez pienākuma.\n– Es gādāšu kūkas. Man māsīca strādā konditorejā.\n– Lai notiek! Tad Edžum jāapņemas sadabūt kaut ko sāļu vai piparotu.\n– Un tu, Zigi? Gribi tikt sveikā cauri?\n– Kā? Man paliek visgrūtākais. Es jūs kontrolēšu.\nNorunājām pēc nedēļas sanākt kopā uz otro un galīgo sēdi, lai noskaidrotu, kas\nizdarīts. Šķīrāmies apņēmības un enerģijas pilni.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2009\/2010"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "No rīta septiņos uzcirtušies mēs, zēni, iegājām klasē. Zigis, klases līderis, izskatījās\ndrūmāks par mums visiem. Bet, kad ieraudzīja Valda sagādātās kūciņas un Edžus atstiepto\ngrozu ar sviestmaizēm, viņa seja noskaidrojās. Jancis no kabatas izvilka trīs aprakstītas\nlapas.\n– Lūdzu, te ir mans referāts! – viņš ar cēlu žestu pasniedza to Zigim.\nZigis pusbalsī mums lasīja priekšā. Referātā bija iepīti gan vēstures fakti, gan slavas\ndziesmas mūsu klases meitenēm.\n– Ziķeris! – Zigis noslavēja autoru. – Bet tu turies pie teksta!\n– Kāpēc es nevaru runāt no galvas?\n– Samuldēsi velns zina ko.\nBet Jancis, mani pavilcis malā, čukstēja:\n– Zini, kurš to uzrakstīja? Mana vecākā brāļa sieva. Viņai uz tādām lietām ķēriens.\nPa to laiku Valdis un Edžus jau bija paguvuši uzklāt galdu.\n– Vai nav brīnišķīgas maizītes? – lielījās Edžus. – Mana vecāmamma jau šorīt\npiecos cēlās, lai pagūtu visu sagatavot.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2009\/2010"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "– Izsaki viņai mūsu vārdā pateicību. Bet es arī neesmu gluži bešā, – un Zigis izvilka\nno somas piecpadsmit vienādas dāvanas.\n– Kā tev ienāca prātā tādas nopirkt?\n– Es apjautājos māsai, ko lai meitenēm dāvina. Izdīcu tēvam naudu, un viņa nopirka.\nVienīgi es biju bešā, un neviens nebija pievērsis uzmanību, ka nav taču ziedu.\nTomēr beidzot Zigis attapās:\n– Ziediņus! Ziediņus!\n– Man nav, – es izdvesu.\n– Ak tu, svilpaste! – Zigis kā satracināts vērsis nāca man virsū. – Lai jods tevi sasper!\nTieši tajā brīdī mani izglāba brīnums. Atvērās durvis, un ienāca mana māte.\n– Es tirgū nopirku pūpolus.\n– Jūs esat mūsu glābēja! – uzsauca Zigis un noskūpstīja manu mammu uz vaiga.\nPēc brīža klasē sanāca meitenes. Viņas aiz pārsteiguma kļuva mēmas. Bet\naudzinātāja, noklausījusies Janča priekšlasījumu, atzinīgi noteica:\n– Izrādās, ka jūs arī bez meitenēm spējat sekmīgi tikt galā.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2009\/2010"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "1. Juniora kartes pamatprincipi 1.1. Karšu izdošana un lietošana bankā notiek saskaņā ar spēkā esošajiem bankas valdes apstiprinātiem noteikumiem. 1.2. Par klientu var būt fiziska persona 7–17 vecumā, kura noslēgusi ar banku līgumu un kurai, pamatojoties uz pieteikumu, banka izdod karti. 2. Līguma noslēgšana 2.1. Klients iepazīstas ar noteikumiem un cenrādi. 2.2. Klients iesniedz bankā aizpildītu pieteikumu un citus bankas pieprasītos dokumentus. 2.3. Banka izskata saņemto pieteikumu un citus iesniegtos dokumentus. Izskatot pieteikumu, bankai ir tiesības pārbaudīt klienta iesniegto informāciju un pieprasīt papildu informāciju no kompetentām valsts pārvaldes iestādēm. 2.4. Bankai ir tiesības klientam atteikt līguma noslēgšanu un kartes izdošanu, nepaskaidrojot atteikuma iemeslus. 2.5. Pieteikuma apstiprināšanas gadījumā banka izdod karti. 2.6. Klients apņemas nekavējoši ziņot bankai par visām izmaiņām, kas skar pieteikumā uzrādīto informāciju, kā arī citu būtisku informāciju.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2009\/2010"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "3. Kartes izdošana 3.1. Banka izdod karti tikai pēc līguma noslēgšanas. Klients karti var saņemt, personīgi ierodoties bankas filiālē. 3.2. Bankai ir tiesības noteikt klientam darījumu ierobežojumus. 3.3. Karte ir bankas īpašums, kas nodota lietošanā klientam. 3.4. Saņemot karti, klienta pienākums ir to parakstīt. 3.5. Banka izsniedz karti kopā ar slēgtu aploksni, kurā norādīts PIN kods. 4. Apdrošināšana 4.1. Klientam saskaņā ar cenrādi ir iespēja izvēlēties apdrošināšanu komplektā ar karti. 4.2. Klients apdrošināšanas atlīdzību var saņemt, uzrādot karti. 4.3. Apdrošināšana tiek izbeigta, ja karte tiek iznīcināta. 5. Kartes lietošana 5.1. Karti drīkst lietot tikai tā persona, kuras vārds, uzvārds un paraksts ir uz kartes. 5.2. Klients ir tiesīgs lietot karti tikai darījumu veikšanai. 5.3. Veicot darījumus pie tirgotāja, klientam pēc apkalpojošā darbinieka pieprasījuma jāuzrāda personu apliecinošs dokuments un ar savu parakstu uz kvīts jāapstiprina darījuma summa. 5.4. Lietojot karti bankas automātos vai tirdzniecības vietās, kas aprīkotas ar PIN koda ievadīšanai piemērotām ierīcēm, PIN kods aizstāj parakstu un tiek uzskatīts par pietiekamu klienta identifikācijas un darījuma apstiprināšanas līdzekli. 5.5. Ja, veicot darījumus, bankas automātā tiek ievadīts nepareizs PIN kods 3 reizes pēc kārtas 10 dienu laikā, karte tiek paturēta bankas automātā. Lai novērstu klienta naudas līdzekļu negodprātīgu izmantošanu, kartes darbība automātiski tiek pārtraukta un tā jāaizvieto ar jaunu karti. 5.6. Klienta pienākums ir rūpīgi glabāt karti un kartes datus, turēt slepenībā PIN kodu.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2009\/2010"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Uzskatu, ka bērniem bankas norēķinu karte dod zināmu neatkarības sajūtu.\nMan patīk, ka mans dēls mācās pats plānot, kā tērēt viņam domāto kabatas\nnaudu. Ja naudas kartē vairs nav, pats vainīgs. Līdzekļus uz dēla karti\npārskaitu reizi nedēļā.\nDana, 9. klases skolniece:\nMan tā īsti bankas norēķinu karte nav vajadzīga. Protams, man jau patīk, ka\ntā ir, bet, pavisam godīgi, varu bez tās iztikt. Skolā jau nav arī bankomāta,\ntāpēc nauda no kartes tik un tā jāizņem citur. Bet klasē kartes ir visiem, un\nkā tad man vienai nebūs?\nRūdolfs, pēdējā kursa students:\nSkolēnu norēķinu kartes irļoti sarežģīts jautājums. Pusaudži irtik izklaidīgi un\nbezatbildīgi, ka viņiem nevar uzticēties, tāpēc norēķinu kartes nevajadzētu\nizsniegt skolēniem, kuri nav sasnieguši 16 gadu vecumu. Agrāk vecākiem\nnebija problēmu bērniem iedot naudu rokā, nez kāpēc tagad visi grib kļūt\npārmoderni un ģimenes attiecības kārtot ar bankas starpniecību.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2009\/2010"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Mikus Mende, kurš šogad mācās Murjāņos un dzīvo dienesta viesnīcā\nA. Kalniņa ielā 4, skolā vēlējās iegādāties Lielbritānijā izdotu mācību grāmatu\nangļu valodas gramatikas apguvei. Tās cena – Ls 16,40. Viņam tik daudz naudas\nnebija, tāpēc Mikus piezvanīja krusttēvam Artūram Finksam, kurš dzīvo Rīgā,\nBrīvības ielā 68 – 14, un lūdza pārskaitīt naudu pa pastu, lai varētu grāmatu\nnopirkt. Krusttēvs šā gada 15. aprīlī devās uz tuvāko pasta filiāli un saņēma\npārveduma orderi aizpildīšanai, lai nosūtītu krustdēlam naudu.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2009\/2010"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Ir karsta 1859. gada aprīļa diena. Sapulcējušies ļaudis raugās uz kādu vīru\nrietumnieku apģērbā. Ar asu cirtienu viņš iecērt kapli smiltīs līdzās plīvojošam Ēģiptes\nkarogam. Šī cilvēka vārds ir Ferdināns de Lesepss. Viņš ir franču diplomāts, kas šo\nsvinīgo brīdi ir gaidījis 27 gadus.\nCirtiens smiltīs ir sākums vērienīgam projektam, par kura īstenošanu viņš ir cīnījies\nvisus šos gadus. Lesepsa lielais projekts ir 163 kilometru gara kanāla būve tieši caur\ntuksnesi. Sākas gadsimtiem ilgi lolota sapņa īstenošana. „Vārti uz austrumiem” saīsinās\njūrasceļu starp Eiropu rietumos un Indiju austrumos un pārvērtīs Āfriku par salu. Lesepsa\npūliņi beidzot ir nesuši ilgi gaidītos augļus. Par godu Ēģiptes vicekaralim Muhammedam\nSaīdam Lesepss vietu, kurā bija jāatrodas pilsētai, nodēvēja par Portsaīdu (Saīda ostu).\nInženieri uzskatīja, ka visvieglāk kanālu būtu uzbūvēt cauri Lielajam Rūgtajam\nezeram un Timsāham, kā arī pa to kanālu atliekām, kurus Senās Ēģiptes faraoni bija\nierīkojuši jau pirms gandrīz 4000 gadu un kurus izmantoja līdz aptuveni 800. gadam.\nArheologi ir atraduši liecības, ka ēģiptieši jau pirms 3900 gadiem bija izbūvējuši\nkuģojamu kanālu no Nīlas uz Sarkano jūru, kas tika dēvēts par Faraonu kanālu. Laika\ngaitā tas aizsērēja un kļuva neizmantojams.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2009\/2010"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Bija nepieciešams izrakt un aizvest projām miljoniem kubikmetru zemes. Dažviet\nkanāls bija jāizcērt arī akmens cietos dabiskā ģipša un sāls slāņos.\nJau vairākus simtus gadu gan jūrasbraucēji, gan politiķi bija sapratuši, ka daudz\npraktiskāk būtu, ja jūrasceļš uz Indiju ietu pa kanālu, kas savienotu Vidusjūru un Sarkano\njūru. Tad kuģiem nebūtu jāveic garais ceļš apkārt visam Āfrikas kontinentam, riskējot ciest\navārijās vai uzbrukumos pie tā krastiem.\nŠī ideja šķita vilinoša arī Napoleonam Bonapartam, kurš 1789. gadā iekaroja Ēģipti.\nNapoleons saprata, ka kanāls palīdzētu Francijai nostiprināt tās pozīcijas Austrumos.\nViņš pats personīgi ļoti interesējās par kanāla būves plāniem un veselas desmit dienas\npavadīja kamieļa mugurā, lai savām acīm aplūkotu apvidu. Turklāt Napoleons zinātnieku\ngrupai uzdeva izspriest, vai ir iespējams uzbūvēt tādu kanālu.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2009\/2010"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Diemžēl Napoleona zinātnieki savos aprēķinos pieļāva nopietnu kļūdu. Viņi\nkonstatēja, ka Sarkanā jūra atrodas gandrīz desmit metrus augstāk nekā Vidusjūra, tādēļ\nkanālā rastos spēcīga straume. Kanāla būves projektu nolika plauktā. Kļūdu aprēķinos\nizlaboja tikai ap 1830. gadu. Jauns pētījums liecināja, ka ūdenslīmeņa atšķirība starp\nabām jūrām ir tik neliela (ap 1,2 metriem), ka tai nebija nekādas nozīmes.\nLesepss sāka sistemātiski pētīt Napoleona vecos kanāla plānus, kad 1832. gadā\n27 gadu vecumā kā diplomāts tika iecelts par Francijas vicekonsulu Aleksandrijā Ēģiptē.\nSākumā viņš visu savu laiku veltīja diplomātiskajiem pienākumiem un drīz vien\nnodibināja labas attiecības ar Ēģiptes vicekarali Muhammedu Alī. Vicekaraļa dēls\nMuhammeds Saīds pie draudzīgā un laipnā franču diplomāta jutās kā mājās. Šī draudzība\nLesepsam ļoti noderēja, kad Saīds kļuva par Ēģiptes reģentu.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2009\/2010"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Lesepss saprata, ka franču būvētam jūrasceļam uz Austrumiem būs lemts iet cauri\nlielās politikas mīnu laukam. Francijai kā koloniālai lielvarai sens pretinieks bija Lielbritānija.\nKopš Napoleona kariem 19. gadsimta sākumā abas valstis atradās pastāvīgā konfliktā.\nLielbritānija dominēja pasaules jūrās un guva lielas bagātības, pateicoties tirdzniecības\nsakariem ar Indiju.\nJau kopš paša sākuma, kad publiskoja pirmos aptuvenos franču kanāla būves\nplānus, nācās piedzīvot ļoti spēcīgu britu politiķu pretestību. Nepatikai pret Napoleona\nkoloniālajiem plāniem bija senas un dziļas saknes – Lielbritānija sajuta draudus pret Britu\nimpēriju. Ar taisnāko ceļu uz Indijas okeānu Francija varētu pārņemt tirdzniecību ar arābu\nzemēm, patiesībā pat nodibināt franču impēriju Tuvajos Austrumos.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2009\/2010"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Protams, britu uzņēmēji saprata, kādas būtu priekšrocības par 5000 kilometru\nīsākam jūrasceļam uz Indiju. Taču tām aprindām, kuras noteica toni politikā, jebkurš\nfrancūža izteiktais priekšlikums jau pašos pirmsākumos šķita aizdomīgs – par spīti tam,\nka Ferdināns de Lesepss apgalvoja, ka kanāls būs pieejams visu valstu kuģiem. Britu pretestībā liela nozīme bija arī kuģu īpašnieku konservatīvajai attieksmei\npret šo projektu. Lai kuģotu pa kanālu, būtu nepieciešami tvaikoņi, kurus vecākie politiķi\nuzskatīja par peldošām bumbām. Uz sauszemes visai bieži notika nelaimes gadījumi, kad\nšuvējas un citi strādnieki applaucējās, eksplodējot tvaika katlam. Uzskatīja, ka jūrā risks\nir vēl lielāks.\nKanālam jau no pašiem pirmsākumiem bija jākļūst par starptautisku projektu, taču\ncilvēki to tā neuztvēra. Pārdošana spoži veicās tikai Francijā. Parīzē vien pārdeva 20000\nakciju, domājams, tāpēc, ka daudzi franči kanālu uzskatīja par Francijas projektu un\natbalstīja to, patriotisku jūtu vadīti.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2009\/2010"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Lesepsam lielu atbalstu sniedza arī māsīca Eiženija, kas bija precējusies ar\nimperatoru Napoleonu III, kurš tobrīd valdīja Francijā. Imperatorei bija liela ietekme uz\nflegmatisko dzīvesbiedru. Vēsturnieki uzskata, ka bez viņas atbalsta kanālu, iespējams,\nneuzbūvētu.\nPar spīti Lesepsa lieliskajiem sakariem un enerģiskajai akciju tirgošanai, viņam\nizdevās pārdot tikai 286000 no 400000 akciju. Vienmēr optimistiskais Lesepss publiski\ngan apgalvoja, ka viss nepieciešamais kapitāls jau ir sagādāts, bet patiesībā viņš devās\nuz Ēģipti, lai atrastu ārkārtas risinājumu. Lesepsam tas izdevās – vicekaralis Muhammeds\nSaīds galvoja par trūkstošo summu.\nPar godu kanāla atklāšanas svinībām Ēģiptes valdība tālaika dižākajam operu\nkomponistam Džuzepem Verdi pasūtīja īpaši sarakstītu operu. Taču opera „Aīda”, Verdi\nslavinājums Ēģiptei, nebija gatava laikā – savu pirmizrādi tā piedzīvoja Kairā 1871. gadā.\nSuecas kanāla atklāšana 1869. gada 17. novembrī kļuva par pasaules mēroga\nsensāciju. Lesepss bija uzaicinājis 6000 ārvalstu viesu, tostarp karaļus un prezidentus\nno visas pasaules. Viesus apkalpoja 500 izcilu pavāru un tūkstotis no ārzemēm atvestu\nviesmīļu.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2009\/2010"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Francijas imperatore Eiženija oficiāli pasludināja kanālu par atvērtu. Skanēja kuģu\ntaures, dārdēja lielgabalu zalves, un 160 kuģi no visas pasaules iebrauca jaunajā kanālā\nar kuģi „l’Aigle” („Ērglis”) priekšgalā. Nākamajā dienā brauciens turpinājās, un 1869. gada\n20. novembrī „l’Aigle” sasniedza Suecas pilsētu un ieslīdēja Sarkanajā jūrā. Kanāls bija\nkuģojams.\nDrīz vien kanālu piepildīja kuģi no visas pasaules – it īpaši no Lielbritānijas.\nF. de Lesepsu uzskatīja par varoni, kurš bija uzņēmies cīņu pret dabu.\nTagad bija skaidrs arī tas, ka kanāls bija izmaksājis divtik dārgi, nekā bija rēķināts\nsākumā, jo Lesepss bija par zemu novērtējis tehniskās grūtības. Sākotnēji būvniecībai\ntrūka arī finansējuma, jo britu pretestība pasliktināja akciju pārdošanas iespējas ārpus\nFrancijas.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2009\/2010"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Sliktā ekonomiskā stāvokļa dēļ drīz vien visi trumpji bija Lielbritānijas rokās. Ēģipte\niztrūkumu bija segusi ar Eiropas banku izsniegtajiem aizdevumiem, bet kokvilnas, Ēģiptes\nsvarīgākās eksporta preces, cenu krišanās dēļ valdība nespēja atmaksāt savus parādus.\nLīdz ar Suecas kanāla atklāšanu 1869. gadā jūrasceļš starp Eiropu, arābu valstīm\nun Āziju kļuva daudz īsāks.\n75 gadu vecumā Lesepss piekrita vadīt jauna – Panamas – kanāla būvdarbus. Tas\nbija milzīgs projekts, bet 1889. gadā šī kanāla būves uzņēmums bankrotēja. Lesepsam\npiesprieda lielu naudas sodu un vairākus gadus cietumā, tomēr šis spriedums tā arī\nnestājās spēkā.\nMūsdienās cauri Suecas kanālam var izbraukt 11–16 stundās, kas nav īpaši mazāk\nkā 1869. gadā. Kuģu ātrums kanālā tiek ierobežots, lai novērstu kuģu dzenskrūvju radīto\nūdens plūsmu ietekmi uz kanāla sienām. Pirmā gada laikā cauri kanālam izbrauca pāris\nsimtu kuģu. Šobrīd satiksmes intensitāte ir pieaugusi līdz aptuveni 20000 kuģu gadā.\nKanāls vairākkārt ir paplašināts un padziļināts. Tā šaurākā vieta ir 300 metru plata. Mazāki\nkuģi var izmainīties bez problēmām, savukārt lielākiem iekārtotas vietas, kur samainīties.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2009\/2010"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Pulksteņa man vairs nav, un vakara laiku es tagad mēdzu nosacīt pēc pretējās mājas diviem\nlogiem. Kad nozūd gaisma, ir tieši vienpadsmit. Kaimiņi ielas viņā pusē ir neiedomājami punktīgi\nļaudis. Pateicoties viņu precizitātei, arī šovakar es zinu, ka jauna diena ir tepat līdzās. Dīki kustos\nvirtuvē, kur atkritumspainis izelpo savu šķebinošo aromātu. Apsēzdamās pašā kaktiņā uz krēsla,\nkurš ir vecs un pie viena moderns, es domāju par to, cik nekaunīgs ir miegs, man uzmākdamies.\nTomēr es vēl nedrīkstu iet gulēt, vismaz līdz jaunās dienas pirmajai stundai jānogaida, citādi\nnaktsmiera nebūs. Es būšu sadusmota, ja šovakar kāds mani apciemos, bet vēl niknāka tad, ja\nnudien neviens vairs neatnāks, jo tikai tādēļ vēl esmu nomodā.\nŠorīt esmu cēlusies agrā stundā, jo vajadzēja sadabūt pienu. Man ir zināms kāds nomaļš\nveikaliņš, kur to nospert ir ļoti vienkārši, jo kastes noliktas durvju priekšā. Tāda maza zādzība ir\ntīrā izprieca, un reizumis es paņemu arī kefīru, bet reti, jo neesmu radusi stiept smagumus.\nAtgriezusies no rīta pastaigas, atkal atlaidos slīpi. Mazliet iemigu, bet tad, pussnaudā, kurš ir\ntik salds un tramīgs, es izdzirdēju pieklājīgus klauvējienus pie durvīm. Izbijos, jo uzreiz iedomājos,\nka atnākusi klases audzinātāja vai kārtības sargi. Tie ir vienīgie, kuri saudzē mana dzīvokļa durvis,\nbet pret mani pašu gan izturas pavisam citādi. Klusie klauvējieni izvērtās nežēlīgā bungāšanā, un\nnācās atvērt durvis.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2009\/2010"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Tā bija mana māte. [..] Mātei atņēma tiesības mani audzināt jau tad, kad vēl nevarēju nostāvēt\nuz savām kājelēm. Ar vieglu sirdi viņa atdevusi mani Alīnai, un par to es tagad esmu pateicīga\nbezgala, jo citādi man būtu jāaug kādā bērnunamā. Alīna bija mana audžumāte, un viņai nekad\nnebūs vairāk kā septiņdesmit divi gadi. [..] Alīnu es mīlēju, kaut neviens tam netic. Viņa atstāja\nmani vienu pirms trim mēnešiem, decembra beigās. Pēdējo reizi pie viņas kapa biju bēru dienā.\nLabprāt aizietu, bet tur nav soliņa, uz kā pasēdēt, un man arī trūkst naudas, lai nopirktu puķes.\nStāvēt kājās pie kapa man nepatīk, es jūtos kā parādniece, bet iet bez puķēm neļauj sirdsapziņa.\nPēc mātes apciemojuma radās vēlēšanās kaut ko ieēst. Slaidi un bezbēdīgi ieslīdēju\nkafejnīcā. Atnesto ēdienkarti pētīju ar tik nopietnu sejas izteiksmi, it kā kabatā būtu vismaz pieci\nrubļi. Pasūtīju šniceli, divas porcijas gaļas salātu, kūku, kafiju, arī šampanieti. Kāpēc neiedzert pie\nviena, ja nav jāmaksā?\nAr lielām pūlēm un milzu pašiedvesmu biju visu notiesājusi un tagad gaidīju izdevīgāko\nmomentu, lai... Piepeši kādai dāmai nokrita kafijas tasīte. Troksnis, ņudzoņa. Neliels apstulbums,\nziņkārīgo acis. Bet nekas šausmīgs. Pavisam neuzkrītošā riksī izskrēju no kafejnīcas.\nPaēst un nesamaksāt atļaujos bieži, protams, kopš man vairs nav Alīnas. Vienmēr bijis\nmazliet žēl to oficianšu, kuras apkrāpju, jo dažreiz viņas mēdz izturēties diezgan laipni. Taču\nnedēļām ilgi man nav ne kapeiciņas. Tiesa, pēc Alīnas bērēm nepilns simtnieks atlika gan, kuru\nes noslēpu vecajā pulkstenī pie sienas. Drīz pēc tam, kad nebiju mājās, pulksteni kāds nospēra.\nNez kādēļ man šķita, ka zinu, kuri ir vainīgie. Tie bija divi no tiem daudzajiem jaunajiem cilvēkiem,\nkuri mēdz ienākt pie manis patrinkšķināt ģitāru vai izdzert pudeli alus, ja nekur citur viņiem durvis\nvairs neatver. ",
+  "KLASE": 12,
+  "MACIBU_GADS": "2009\/2010"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Ja varētu paļauties uz sevi, tad jādomā, ka rudenī man jau būtu pašai sava nauda. Ja vien\nsākšu strādāt. Bet domas par darbu mani morāli grauj. Ir marts, un saulainais laiks jau pavisam\ntuvu, bet kurš tad vasarā strādā? Es, starp citu, ātri iesauļojos un tad izskatos daudz pievilcīgāka.\nTādēļ nevaru šai laikā atļauties sēdēt pie konveijera. Vēl nekad neesmu strādājusi, arī vasarās ne,\njo Alīna to nevēlējās. Es esmu ļoti trūcīga, un patiesībā sava ir tikai tā drēbju kārta, kas patlaban\nmugurā, bet man ir iejūtīgas un saprotošas draudzenes, kuras dažkārt atdāvina savas apnēsātās\ndrēbes. Viņas ir brīnišķīgas meitenes, tikai diemžēl tuklākas par mani. [..]\nAr Emīlu draudzējos jau ilgāku laiku un gribu ticēt, ka mēs itin drīz apprecēsimies. Emīlam ir\nturīgi vecāki un pašam pieder mājas augšstāvs. Viņa māti gan vēl neesmu redzējusi, bet domāju,\nka Emīls mūs vēl sapazīstinās. Viņš ir glīts un naudīgs puisis un reizumis iešķiebj man kādu desmitnieku, tomēr ne tik bieži, kā atļautu viņa ienākumi, kuri ienāk nezin no kurienes.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2009\/2010"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Gurda un nogurusi no pārēšanās, lēni vilku kājas pa kāpnēm. Bez mazākā satraukuma\niegāju pa dzīvokļa pusatvērtajām durvīm. Šorīt, projām ejot, biju tās cieši pievērusi. Palūkojos\ngrīdā – uz tās kusa mazi sniega gabaliņi, ko atstājis nesenais nācējs. Kāds atkal vēlējies satikt\nmani vai varbūt mani ne, tikai manas telpas. Nav pat nojautu, kurš tas bijis. Tagad šeit mēdz\niegriezties tik daudzi, ka visiem pat neesmu noskaidrojusi vārdus. Tas arī nav svarīgi, es tikai\nvēlētos drīzāk atbrīvoties no šiem ciemiņiem, kurus nekad neesmu lūgusi.\nEs vēlējos lasīt. Es lasu maz un lēni – kā pamatskolniece. Paņēmu kādu no Egila Lukjanska\nsaistošajiem romāniem. Bet vispirms iedomājos, ka būtu lietderīgi aizbarikādēt ieeju dzīvoklī ar\nledusskapi. Tas ir neliels, taču izturīgs pret triecieniem. Lasāmviela tiešām bija interesanta, bet man\nātri uzmācās snaudiens, kāds parasti pārņem pēc pusdienām, par kurām neesmu samaksājusi.\nAkurāt tādā pašā nomidzī varu ieslīgt arī tad, ja visu dienu neesmu neko ēdusi.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2009\/2010"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Pēc trijām vai sešām stundām izdzirdēju, ka aiz durvīm sevi piesaka kāds atnācējs. Bija\nieradušies kārtības sargi, jo es kopā ar savu dzīvokli atrodos milicijas uzskaitē. Ik pārvakaru šie\nmani apmeklē, lai iebāztu savus degunus skapī, mazmājiņā un pieliekamajā kambarī, cerēdami\ntur atrast kādu no maniem neskaitāmajiem paziņām. Šoreiz jutos mierīga, jo biju viena.\nPēc viņu aiziešanas sēžu te virtuvē un ik pa brītiņam paveros spogulī un mēģinu izprast,\nkāpēc šie sargi vispār pie manis nāk.\nPēdējā laikā man labāk patīk iet gulēt, nekā atmosties no rītiem, jo rītos man vienmēr\njāizdomā, kā aizvadīt priekšā stāvošo dienu. Šorīt izprātojos visādi un tomēr neko sev piemērotu\nnevarēju atrast. Vienubrīd pat iedomājos, ka varētu atkal sākt iet skolā. Celties no rītiem un\nmācīties vakaros. Skolai tomēr ir miljons visādu labumu. Pirmkārt, tur var paēst pusdienas un\nkrietnos daudzumos sasperties rupjmaizi, tādējādi nodrošinot sev vakariņas. Ne jau tik smalkas\nkā citiem, bet tomēr vakariņas.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2009\/2010"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Otrkārt, var aizņemties no daudzajiem paziņām pa rublēnam, un\nman no pieredzes zināms, ka tik mazītiņu summiņu neviens negaida atdodam. Treškārt, stundu\nlaikā gandrīz netraucēti varu lasīt grāmatas, ko reti varu darīt mājās. Man visu laiku šķiet, ka\nskolotāji cenšas no manis atbrīvoties. Zinu, ka viņi būtu daudz sajūsminātāki, ja tiem izdotos mani\nieslodzīt specskolā. Galu galā skolā par mani neviens nerūpējas, jo visi nodarbojas tikai ar to, lai\npozitīvos skolēnus padarītu vēl pozitīvākus un slavētu. Sabiedrisko darbu es neatzīstu, un vēl\ntad, kad uz stundām ierados puslīdz regulāri, man bija jāklausās smieklīgās runas par to, it kā es\nneko nedarot lietas labā. Vientiesīgi atzinos, ka neredzu to lietu, kuras labā kaut kas būtu jādara,\nun kopš tā laika esmu ieskaitīta negatīvajos skolēnos. Bet es par to nospļaujos. Skaitos visai\nskandaloza persona, kaut pēc rakstura esmu paklusa; tomēr mazliet neprātīga jau arī. Un, ja es\ntagad ierastos skolā, varu jums apzvērēt, ka uz mani skatītos tā, it kā būtu noslepkavojusi savu\nkaimiņieni vai izdarījusi kaut ko vēl trakāku. It kā tas, kā es dzīvoju, būtu kāds šausminošs fakts,\nnekā briesmīga taču nav, vienīgi pašai ļoti grūti.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2009\/2010"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Biju pagurusi no šīs prātošanas un tālab nolēmu pastaigāt pa veikaliem cerībā, ka varbūt\nizdosies kaut ko nočiept. Kaut vai kafiju, ko uzvārīt Emīlam, kad viņš atnāks. [..]\nPēc pusdienlaika Emīls tiešām atnāca, un es nopriecājos par savu akurāto izskatu. Bet viņš\nizskatījās sapīcis. Tad, iegājis virtuvē, paziņoja, ka gribot izmazgāt matus.\n– Vai tu taisies kaut kur iet?\n–Nekur neiešu, palikšu pie tevis, vienkārši sasvīdusi galva, – viņa balss bija ļoti nogurusi.\nEmīls brīdi pašķendējās par to, ka man nav šampūna, un tad izmazgāja matus ar dzeltenu\nziepju kriksīti. Šo ieapaļo gabaliņu es uzgāju šujamo piederumu kastītē. Alīna ar to zīmēja līnijas\nuz auduma, kad piegrieza man svārkus.\n–Vai, kāds tu izskaties smieklīgs ar izmazgātu galvu! – es iesaucos.\n–Vai tad citi izskatās savādāk, kad izmazgā galvu? – Emīls naidīgi atjautāja.\n–Es nemaz nezinu, kā citi izskatās!\n– Jā, jā, – viņš pasmīkņāja, – tu jau nu gan esi īstā, kas nezina.\nEs neatbildēju. Iegāju istabā un apsēdos uz trīskājainās tahtas „Lira”. Raudzījos caur logu,\nkurš netīrumu dēļ jau līdzinājās matētam stiklam. Rāmi un domīgi slīdēja mākoņi, kuros es vēlējos\niegrimt. Virtuvē ne skaņas. Tad Emīls tomēr atšļūkāja līdz istabai un nevērīgi atbalstīja muguru\npret sienu.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2009\/2010"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "–Varbūt tu man varētu uzvārīt tēju, ko? – viņš prasīja, jo zināja, ka kafija jau sen izbeigusies.\nŠai mirklī nožēloju to, ka neaizgāju līdz veikalam, lai nozagtu kafiju. [..]\n–Ak kungs, tev pat tējas vairs nav?\n– Bet man taču nav naudas, mīlulīt.\n–Neuzrunā mani tā – „mīlulīt”, – viņš saviebās. Klusēju un skaudīgi nolūkojos mākoņos.\n–Emīl, vai tu man vari aizdot kādus desmit rubļus? – beidzot sadūšojos un ievaicājos.\n– Man nav tik daudz naudas priekš tevis, mīlulīt! – viņš iesaucās ar tādu ironiju, ka man\nvajadzēja būt pēdējai muļķei, lai to neuztvertu.\n– Neuzrunā mani tā – „mīlulīt”, – atteicu viņam to pašu, nolēmusi, ka neļaušu par sevi\nņirgāties.\n–Vajag atšķirt intonācijas, mīļā!\nNu man vairs nebija ko atbildēt. Bet naudu tomēr vajadzēja.\n– Ja tev nav desmitnieka, varbūt tu varētu iedot vismaz kādus piecus rubļus, – es pazemojos.\nViņš neatbildēja, tikai staigāja pa istabu, purinot galvu uz visām pusēm. Līdzko mati bija\nizžuvuši, Emīls, stīvi atvadījies no manis, aizgāja.\n–Nākamreiz nopērc kafiju, – uz sliekšņa stāvēdams, viņš sacīja, – un šampūnu arī.\nPēc šīs sarunas jutos tik nelāgi, ka aizgāju gulēt, neaizbīdījusi durvīm priekšā pat ledusskapi.\nUzmodos no paskaļās kņadas aiz durvīm. Bija atnākušas visas četras manas sirsnīgākās\ndraudzenes – Ieva, Līga, Edīte un Aiva. Tās ir manas klasesbiedrenes un neko daudz cita no citas\nneatšķiras. Viņas tikai vēlas būt neatkarīgas.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2009\/2010"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Ieva un Līga, lai gan smaidīja, izskatījās noslēpumainas, Edīte ar Aivu ­– neparasti lustīgas.\nNosēdāmies visas ap manu lielo galdu. Cita citu pārkliedzot un žestikulējot, viņas sāka stāstīt\npēdējos jaunumus par dzīvi skolā. Aizrāvušās viņas klaigāja tik skaļi, ka man nācās aizrādīt.\nJo kaimiņi var atkal izsaukt kārtības sargus, kaut vairāk ticams, ka tie ieradīsies paši. Uz mirkli\nvalodas pierima, tad atkal iezvanījās, un es sapratu, ka veltīgi viņām aizrādīt. Tas tak ir mans\ndzīvoklis, kurā visi visu atļaujas. Edīte izvilka divas pudeles vīna, ko bija nočiepusi mājas bāriņā.\nPiecu mazu glāzīšu manā mājā nebija, bet viena tējas glāze ar nograuztu maliņu atradās. Īpaši\ndzert nevēlējos, taču atteikties nevarēju. Iestājās mazliet svinīgs apmulsums, jo tajā brīdī Līga\nman pasniedza burciņu ar rasolu, trīs žāvētus lučus un lielu tortes gabalu. Zināju, ka vakar bija\nviņas dzimšanas diena. Saprotams, es netiku ielūgta, taču man nav tiesību apvainoties, jo otrā\ndienā pēc draudzeņu jubilejām arī es vienmēr esmu labi paēdusi. Šoreiz tā gluži vis nebija, jo arī\nAiva un Edīte jutās izsalkušas, tālab rasolu apēdām trijatā. Kūku veikli noslēpu ledusskapī. Līga\nar Ievu aši ieslīdēja virtuvē, līdzi paņemot trīs žāvētos lučus. Man bija kauns skriet abām līdzi un\nsacīt, ka zivtiņas domātas man. ",
+  "KLASE": 12,
+  "MACIBU_GADS": "2009\/2010"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Eu, man ir kolosāla ideja! – Aiva pēkšņi iesaucās, paķēra Edīti aiz rokas, un abas iztesās\nkāpņu telpā.\nLīdzās manas visniknākās kaimiņienes durvīm ir nolikta metāla vanna, un Aiva bija\nnodomājusi piestumt to viņas durvīm priekšā.\n– Lai netiek ārā, – Edīte lietišķi paskaidroja. Vanna izrādījās pārāk skanīga un smaga. Es\nredzēju, ka to ir grūti pacelt, bet palīgos arī nedomāju iet. Iespiedusi rokas sānos, stāvēju uz\nsliekšņa un skatījos. Man bija uzjautrinoši un reizē ārkārtīgi skumji. Redzēju, kā viņas pūlējās, un\narī to, ka, nespēdamas vannu pacelt, viņas sāka to vilkt pa grīdu. No milzīgās piepūles, no alus un\nvīna Aivai kļuva pavisam nelabi.\nKaimiņtante, kurai piederēja vanna, acīmredzot bija izgājusi. Taču, lai mēs nepaliktu\nnesodītas, durvis atvēra otra niknākā būtne mūsu mājā. Viņa uzmeta plecos mēteli un klusējot\nskrēja lejup. Tūdaļ sapratu, ka pēc dažām minūtēm ieradīsies kārtības sargi. Ievilku Aivu istabā,\nkaut gan viņa pretojās. Ieslēdzām televizoru un sēdējām rātni kā skolasbērni.\nKārtības sargi atskrēja tik veikli, it kā šeit būtu ugunsgrēks. Štābā par mums visām sastādīja\nprotokolu. Nezināmu iemeslu dēļ man atļāva iet mājās. Kautrīgi palūdzu, lai atlaiž arī draudzenes,\nbet kāds vīrs mani saudzīgi izstūma pa durvīm. Priecīgi palēkdamās, skrēju mājup un ne par ko\nvairs nedomāju.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2009\/2010"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Kūru vadonis Indulis iemīl vācu bruņinieka\nmeitu Āriju. Viņš seko savai sirdsbalsij un dodas\nuz vācu ieņemto Embotes pili cerībā samierināt\nabas naidīgās puses, lai beidzot zemē iestātos\nmiers. Taču saprašanās starp kūriem un vāciem\nnav iespējama. Izpratis situācijas traģismu, Indulis\natgriežas pie savas tautas.\nVai Indulim un leišu vadonim Mintautam izdosies\nrast kopīgu valodu cīņā pret vācu krustnešiem?",
+  "KLASE": 12,
+  "MACIBU_GADS": "2009\/2010"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Rīga ir Latvijas galvaspilsēta – mūsu valsts lielākā pilsēta, izglītības un kultūras,\nekonomiskās un politiskās dzīves centrs. Rīga izveidojusies netālu no Daugavas\nietekas Rīgas jūras līcī un atrodas pašā Latvijas centrā.\n Par Rīgas dibināšanas gadu uzskata 1201. gadu, bet apdzīvota vieta šeit,\nDaugavas piekrastē, ir bijusi jau senāk. Rīga vienmēr ir izcēlusies starp Baltijas\nvalstīm, jo tā bija un ir svarīga tirdzniecības un ostas pilsēta. Atšķirībā no daudzām\ncitām Eiropas valstu pilsētām Latvijas galvaspilsētai vienmēr ir bijis tikai viens\nnosaukums – Rīga. Vārdu pilsētai ir devusi nelielā Rīdzenes upe, kas gan laika\ngaitā ir aizbērta un vairs nav redzama.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2010\/2011"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Mūsdienu Rīga plešas gar abiem Daugavas krastiem. Tās lepnums ir senākā\npilsētas daļa – Vecrīga Daugavas labajā krastā. Pilsētas panorāmā labi\npamanāmas vēsturiskās celtnes, kas kļuvušas par tās simboliem – Rīgas pils,\nSvētā Pētera baznīca un Rīgas Doma baznīca. Rīgas pilī atrodas Latvijas Valsts\nprezidenta rezidence – darba telpas. Īpaši ievērojams ir pils Svētā Gara tornis,\nkurā vienmēr plīvo Latvijas valsts karogs.\n Rīgas Doma baznīca lepojas ar senu vēsturi. Tās pamatakmens ir likts\njau 1211. gadā. Doma baznīcas ērģeles ir otras lielākās Latvijā un vienas no\nlielākajām pasaulē. Vislielākās mehāniskās ērģeles pasaulē atrodas Liepājā\nSvētās Trīsvienības baznīcā.\n Rīgas Doma baznīcas ērģeles ir vairāk nekā gadsimtu vecas. Ērģeļu stabules\nir izgatavotas no dažādiem kokmateriāliem: priedes, egles, kļavas, dižskabārža,\nbumbieres,ozola.Domaslavenoērģeļuskanējumsirdzirdamsgandievkalpojumos,\ngan arī koncertos.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2010\/2011"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Starp papardēm vijās grūti saskatāma taciņa, to lietoja tikai meža zvēri un putni. Saules stari\nlauzās cauri biezajai koku lapotnei un nelielos plankumiņos klājās uz koku stumbriem un lapām.\nVirs taciņas peldēja mazs Mākonītis, tas pēc skata atgādināja plāno pankūku ar aveņu ievārījumu,\nkura vēl apetītelīgi un gardi smaržoja. Viņš lēnām peldēja uz priekšu un ne par ko neuztraucās.\nPa taciņu rāpoja Gliemezis. Viņš nupat bija ieturējis brokastis un tagad jutās mierīgs un\nlaisks. Gliemezis nesteidzīgi rāpās uz priekšu, viņš mēroja ierasto ceļu cauri paparžu audzei\nlīdz meža pļaviņai, kur viņš tikās ar citiem gliemežiem, pārrunāja meža jaunumus un ieturēja\npusdienas.\nNebija skaidrs, kurš no viņiem – Gliemezis vai Mākonītis – virzījās uz priekšu lēnāk, taču\ndiena bija tikai sākusies, koku lapas klusām šalkoja, un likās saprotami, ka neviens šādā laikā\nnekur nesteidzas.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2010\/2011"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Gliemezis sajuta pankūku smaržu. „Interesanti,” viņš nodomāja. „Turklāt tā ir ar avenēm. Tas\nir pilnīgi neizskaidrojami.” Tad viņš uzmanīgi palūkojās visapkārt, pacēla acis uz augšu. Papardes\nviņam virs galvas liegi pašķīrās. Tās atklāja skatam augstākos koku zarus, caur kuriem plūda\nsaules gaisma, un mazu zilas debe______ gabaliņu.\nGliemezis samiedza acis saulē un tad ieraudzīja mazu Mākonīti. Tā malas bija nedaudz\nizplūdušas un neskaidras, taču tik un tā ļoti labi varēja redzēt, ka tas ir līdzīgs plānai pankūkai.\n„O!” nodomāja Gliemezis. Nekas cits viņam vairs nenāca prātā, un viņš uz brīdi sastinga.\nMākonītis turpretī jau labu laiku bija Gliemezi novērojis. Lai arī viņš izlikās Gliemezi\nnemanām, Mākonītis gribēja atstāt labu iespaidu. Tādēļ viņš nolaidās vēl zemāk un piepūtās, un\naveņu smarža strāvoja uz visām pusēm.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2010\/2011"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Pēc tam Mākonītim apnika izrādīties, un viņš nolēma doties tālāk. Viņš pacēlās mazliet\naugstāk un tad sāka griezties ap kādas priedes stumbru. Tas bija diezgan apjomīgs, un saules\ngaisma to apņēma ciešā lokā. Labu laiku virpuļodams, Mākonītis mazliet nogura un nolēma\natpūsties. Viņš iekārtojās starp priežu skujām un palūkojās, vai tuvumā nav kāds sarunu biedrs.\nTā kā pa priedes stumbru rāpoja Skudra, viņš vērsās pie tās. „Vai zināt,” viņš teica. „Gliemežiem\ntomēr trūkst humora izjūtas.” Skudra uz brīdi apstājās, (itkā, it kā) pārdomājot (tiko, tikko)\ndzirdēto, un tad atbildēja: „Jā, gliemeži turklāt ir arī lieli lēnprāši.” Tad viņa aizrāpoja tālāk un\npazuda no Mākonīša redzesloka.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2010\/2011"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Gliemezis pa to laiku jau bija sasniedzis meža pļavu, tur auga dažādas puķes un klājās\nmīksts sūnu paklājs, kas Gliemezim ļoti patika. Mazliet aizelsies un nosvīdis, Gliemezis nolēma\nnosnausties kāda pudura paēnā, kamēr pļavā ieradīsies pārējie Gliemeža biedri. Pirms laišanās\nmiegā viņš pārdomāja rīta cēlienu un atcerējās Mākonīti, kas izskatījās pēc plānas pankūkas un\nsmaržoja pēc avenēm.\n„Varbūt tas bija mans iztēles auglis. Vienalga, tas izskatījās visai iespaidīgi,” Gliemezis\nnodomāja. „Žēl, ka nesanāca iepazīties tuvāk, bet mākoņi, kā zināms, ir lieli vienpaši, it īpaši tie,\nkas smaržo pēc avenēm.”\nTad Gliemezim pāri pārlaidās milzīga spāre un uz saviem caurspīdīgajiem spārniem aiznesa\nprojām viņa domas.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2010\/2011"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Latvijas Nacionālais vēstures muzejs – latviešu tautas materiālās kultūras vērtību\nlielākā krātuve – dibināts 1869. gadā kā Rīgas Latviešu biedrības Zinību komisijas muzejs. Lai\nlabāk izprastu tā rašanās iemeslus un mērķus, jāiepazīstas ar situāciju Rīgā vairāk nekā pirms\nsimt gadiem.\nLīdz pat 19. gs. 60. gadiem Rīga bija pilsēta – cietoksnis, kuras izbūvi un saimniecisko\nattīstību noteica dažādi militāri stratēģiski apsvērumi. Tikai pēc nocietinājumu nojaukšanas\nsenā tirdzniecības pilsēta sāka pārveidoties par modernu rūpniecības centru ar daudznacionālu\niedzīvotāju sastāvu. Pēc 1867. gada tautskaites datiem Rīgā no 102 590 iedzīvotājiem 42,9% bija\nvācieši, 25,1% krievi un 23,6% latvieši. Rakstnieks Matīss Kaudzīte devis šādu savas tautas\nraksturojumu: „Līdz pagājušā gadsimteņa vidum latvietis sevi nepazina un nesauca citādi\nkā par zemnieku, jo tā viņu sauca visi, kas tolaik šķita augstāki par viņu vai arī patiesi bija\naugstāki. Pēc sava darba un stāvokļa viņš arī cits nekas nebija kā tikai zemnieks. Ja arī\nkādreiz kur minēja „latvieti”, tad tomēr šo nosaukumu saprata tikai tā paša zemnieka nozīmē\nvien, jo neviens nespēja domāt, ka zemnieks un latvietis esot divi pavisam šķirti jēdzieni.”",
+  "KLASE": 9,
+  "MACIBU_GADS": "2010\/2011"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Rīgā nonākušie un pie bagātības tikušie latvieši iemācījās runāt vāciski un bieži\nvien savu izcelsmi noliedza. Nebija viegli pilsētā atrast savus tautiešus. Situācija mainījās\n19. gs. otrajā pusē, kad pēc zemniekus diskriminējošu likumu atcelšanas latvieši arvien lielākā\nskaitā ieplūda Rīgā un viņu dzīvesveids mainījās. Veidojās latviešu pilsonība un inteliģence,\ncēlās latviešu tautas nacionālā pašapziņa, un latviešiem radās nepieciešamība pēc savas\norganizācijas, kur tautiešiem satikties, lietderīgi un kulturāli pavadīt brīvos brīžus, papildināt\nzināšanas utt.\n 1868. gadā nodibināja Rīgas Latviešu biedrību (turpmāk RLB), kuras sastāvā darbojās\nvairākas kultūrizglītojošas komisijas. Viena no tām, 1869. gadā izveidotā Zinību komisija,\nuzsāka muzejisku priekšmetu vākšanu, lai radītu Latviešu muzeju. Jaunais muzejs savas\ndarbības pirmajos gadu desmitos pieņēma visu, ko tam dāvināja. Līdz ar arheoloģijas,\netnogrāfijas un numismātikas kolekcijām vāca arī ģeoloģijas, botānikas un zooloģijas\nmateriālus. Pirmā īslaicīgā etnogrāfiskā izstāde tapa tikai 1890. gadā RLB telpās.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2010\/2011"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Gatavojoties X Viskrievijas arheoloģijas kongresam Rīgā, 1896. gadā RLB nolēma sarīkot\nlatviešu etnogrāfisko izstādi. Lai to sagatavotu, Zinību komisija nosūtīja uz dažādiem Latvijas\nnovadiem 10 zinātniskas ekspedīcijas muzejisku priekšmetu vākšanai. Tika iegūti vairāk nekā\n6000 etnogrāfisku priekšmetu un rosināta latviešu sabiedrības interese par savas tautas\nvēsturi. 1895. gadā publikas apskatei atvēra muzeja ekspozīciju. Tas pavēra jaunas iespējas\ntautas izglītošanā un nacionālās pašapziņas celšanā.\n 1903. gadā RLB nopirka sev jaunu ēku Pauluči ielā (tag. Merķeļa iela), kur bija atvēlētas\ntelpas muzejam. 1914. gadā par latviešu tautas saziedotiem līdzekļiem sākās speciāli muzeja\nvajadzībām projektētas ēkas celtniecība, taču to pārtrauca Pirmais pasaules karš, un projektu\nvairs nerealizēja. Pēc Latvijas valstiskās neatkarības pasludināšanas 1918. gadā RLB Latviešu\nmuzeja krājumu nodeva valsts rīcībā. 1920. gadā tam piešķīra telpas Rīgas pilī. 1924. gadā ar\nīpašu likumu muzejs ieguva valsts muzeja statusu un jaunu nosaukumu – Valsts Vēsturiskais\nmuzejs.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2010\/2011"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Šis sauklis šķiet pilnīgi pamatots, taču neviena no mūsu pāri par 40 politiskajām partijām\nnav to ierakstījusi savā programmā. Patiesību sakot, tas jau sen ir īstenots, katram cilvēkam\narvien ir bijis savs vārds, t. i., personvārds, vismaz, ja runājam par to laiku, ko aptver vēstures\natmiņa. Rakstisku liecību par vārda esamību sniedz jau vissenākais literatūras piemineklis,\nšumeru un akadiešu eposs „Gilgamešs”, kas pierakstīts ķīļrakstā uz māla plāksnītēm vairāk nekā\ndivus tūkstošus gadu pirms Kristus dzimšanas. Šajā eposā stāstīts par valdnieku Gilgamešu,\nkura prototips dzīvojis 27.–26. gadsimtā pirms Kristus, un viņa tēvu Lugabandu, par valdnieka\nkalpu Enkidu un Gilgameša cīņu ar cita valdnieka – Agas – vadīto karaspēku.\n",
+  "KLASE": 9,
+  "MACIBU_GADS": "2010\/2011"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Protams, šis eposs, lai arī cik sens, radies tomēr samērā attīstītā civilizācijā, bet\ncilvēkiem vārdi bija acīmredzot jau pirmatnējā sabiedrībā; par to liecina arī mūsdienu etnogrāfu\nvērojumi pat visprimitīvākajās ciltīs. Tāpēc arī viens no antīkās pasaules lielākajiem ģēnijiem\nHomērs varēja droši un pamatoti gluži mūsdienīgā zinātniskā līmenī apgalvot: „Nav jau starp\nmirstīgiem tāda neviena, kam nebūtu vārda, \/ Vai nu tas būtu no augstākas, vai zemākas kārtas,\njo vienmēr \/ Vecāki katram dod vārdu, kad cilvēks ir pasaulē nācis.” („Odiseja”, 8. dziedājums.)",
+  "KLASE": 9,
+  "MACIBU_GADS": "2010\/2011"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Kaut gan mūsdienās zemeslodes iedzīvotāju kopskaits ir jau seši miljardi, daudzkārt\npārsniedzot Homēra laikabiedru skaitu, tomēr tikko minētais sengrieķu dzejnieka apgalvojums\nnav zaudējis aktualitāti. Personvārds nav vis „lieka greznība”, bet nepieciešamība; ja nebūtu personvārdu, kā\ngan varētu atšķirt, reģistrēt vai uzrunāt kādu vienu cilvēku no daudziem? Var, protams, izlīdzēties\nar iesauku, palamu, taču arī tā no valodniecības viedokļa ir specifisks personvārdu paveids. Bet vai tiešām obligāti vajadzīgs vārds, vai nevarētu iztikt, piemēram, ar numuru vai\nskaitļu un burtu kombināciju? Šādā veidā, kā zināms, var izdalīt un nosaukt, piemēram, katru atsevišķo automašīnu starp miljoniem visādi citādi savā starpā līdzīgajām. Dažā labā zinātniski\nfantastiskā romānā šāds cilvēku apzīmēšanas veids ir aprakstīts, varam atcerēties arī kaut ko\nlīdzīgu, attiecinātu uz cilvēkveidīgām skudrām nesen rādītajā animācijas filmā „Skudra Z”. Pavisam\nreāli cilvēku numerācija, atņemot viņiem vārdu, bija ieviesta totalitāro režīmu koncentrācijas\nnometnēs, kļūdama par vienu no cilvēka pazemošanas elementiem. Turpretim sagaidīt, ka cilvēki\nno brīvas gribas piekristu kļūt par numurētiem bezvārda elementiem, nudien nav nekāda pamata.\nTiesa, modernajos lielpilsētu džungļos cilvēks brīžiem var savu vārdu tomēr pazaudēt un kļūt par\n„pilsoni ar hūti” vai sešdesmitgadīgu „meitenīti”, bet labākajā gadījumā par „kundzīti”.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2010\/2011"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Savs vārds gan pieder katram cilvēkam, bet ne jau paša sagādāts (izņemot, protams,\nsamērā retos personvārda oficiālas maiņas gadījumus). Parasti tie ir vecāki, kas savam bērnam\nsagādā ne tikai autiņus un šūpuli (vai pamperus un importa ratiņus) pirmajiem dzīves mēnešiem\nun gadiem, bet arī vārdu, kas valkājams nenovalkājas visu mūžu un, ja cilvēks to ir pelnījis, tiek\ndaudzināts arī vēl nākamajās paaudzēs. Tāpēc vārda došana jaundzimušajam ir gauži atbildīgs\nuzdevums, un ar to saistās daudzi ticējumi un ieražas. Senajiem romiešiem bija paruna nomen et omen (vārds un novēlējums, pareģojums),\nkura atspoguļo ticību tam, ka katra cilvēka vārds var ietekmēt un ietekmē šī cilvēka likteni. Tāpēc\nvecāki sava bērna vārdā centās ietvert tos novēlējumus, kas šķita visnozīmīgākie. Tiesa gan,\nmums pierasts, ka bērnam cenšas atrast labskanīgu vārdu, kas rada tīkamas emocijas, piemēram,\nIeva, Smuidra, Dzidra, Skaidrīte, Dzintars, Valdis, taču pasaules praksē var sastapt arī vārdus ar\nnozīmi ’suņaste’, ’muļķis’, ’smirdošais’, ’atkritums’.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2010\/2011"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Meitenes mēdz saukt vārdos, kas it kā iemieso skaistumu un grāciju. Daudzi sieviešu\npersonvārdi cēlušies no puķu nosaukumiem, piemēram, Lilija, Roze, Madara, Narcise. Daudz, daudz biežāk tomēr, dodot vārdu jaundzimušajam, šajā vārdā cenšas ietvert\nnepārprotamu laba novēlējumu. Ja no zēna grib sagaidīt izaugam drosmīgu un spēcīgu vīru, tad\nvar bērnu nosaukt kāda varena zvēra vārdā: Leo, Leons, Leonīds. Izturības un rakstura stingrības simbols daudzām tautām ir akmens. Tieši šāda nozīme\nir tadžiku peronvārdam Sangs un uzbeku – Tošs. Pirms vairākiem gadsimtiem krieviem bija vīriešu\nvārds ar to pašu nozīmi – Kameņs; liecības par to saglabājušās arhīvos un visai izplatītajā uzvārdā\nKameņevs (tas sākotnēji bijis tēva vārds – Kameņa dēls). Un arī mums visiem labi zināmais\nPēteris (tāpat kā krievu Pjotrs, angļu Pīters, itāliešu Pjetro, somu Peka u. c.) cēlies no sengrieķu\nvalodas sugasvārda petros ’akmens, klints’ (sal. petroleja – burtiskā tulkojumā ’akmens eļļa’).",
+  "KLASE": 9,
+  "MACIBU_GADS": "2010\/2011"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Gribu izstāstīt savu bēdu! Mūsu draudzīgajā kompānijā es pēkšņi sajutos kā piektais ritenis.\nNebiju pārliecināts, ka situācija jebkad uzlabosies kaut vai par mata tiesu, drīzāk tas nekad\nnenotiks.\nLīdz šim likās, ka mūsu kompānijā visi sadzīvoja kā cimds ar roku. Kur var pazust draudzība,\ntā ir kā akā iekritusi. Kāpēc viss pasaulē notiek tik ačgārni? Jūtos kā izmests uz sēkļa.\nNepateicība – pasaules alga! Ja kāds neprata izpildīt vēstures mājasdarbu, es to vienmēr citiem\npratu ieliet kā ar karoti. Tagad visi varēs kost pirkstos!\nCerams, ka neesmu aizvainojumā uzpūtis no mušas ziloni, varbūt rīt viss nokārtosies, jo\ncilvēks domā – dievs dara.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2010\/2011"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Pēc matemātikas es pierunāju Dārtu nākt pie manis. Mēs esam sirdsdraudzenes, un mūsu mammas ļauj iet ciemos vienai pie otras. Dārta pie manis ir bijusi jau daudzas reizes. Tā kā es dzīvoju netālu no skolas, līdz mājām kādas piecpadsmit minūtes, tad jau ap vieniem esam mājās. Matemātika beidzās 12.45, tad pārvilkām maiņas apavus, sandales ielikām maisiņos un katra pakārām uz saviem āķīšiem garderobē. Es dzīvoju tajā zaļajā mājā, kur pagalmā manis zīmētās krītiņu princeses, uz vienu pusi Radio SWH, uz otru — trako māja. Zem logiem uzreiz iela, pa kuru brauc 3. trolejbuss. Man patīk sēdēt pie loga ar mammas šprici rokā un uzšļacīt ūdeni tiem, kas iet apakšā, tad ātri nosēsties zem palodzes un rāpus uz istabu, kur logam priekšā aizkari un mani neredz. Mūsu mājai ir divi stāvi. Katrā stāvā ir četri dzīvokļi. Mums ir vienistabas, tāpat kā manai kaimiņienei Sigitai. Pārējiem laikam arī tikai viena istaba.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2010\/2011"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Tur tālāk ir mazdārziņi. Mamma man tur aizliedza iet, jo tur ir slikti onkuļi.Aiz pagalma ir šķūnīši un liela bedre, kur dzīvo tie kukaiņi ar daudzajām kājām un tādi apbruņojušies, vēl tur aug zili cigoriņi un saldās nātres, no kurām var izzīst veselu medus paradīzi. Mūsu šķūnītis ir sešpadsmitais, tur stāv manas ragavas. Piekaramajai atslēgai priekšā karājas liela, melna gumijas klape, lai slēdzene nesarūsē. Kad tuvojamies mājām, es apstādinu Dārtu uz paugura pie šķūnīšiem, lai parādītu vakardienas sekreķikus — vakar es ieraku vaboli, divas pienenes, salūzušo matu sprādzi ar rozīti un īrisa ziedlapu, tas viss ir mazā bedrītē zem stikla, kuru es tagad atroku, lai parādītu draudzenei. Pirms iešanas iekšā mēs vēl aizlienam aiz šķūņiem. Tur ir sekls grāvis, un aiz tā uzreiz mazdārziņu sēta. Grāvī ir misene. Tur visi tusē, mamma teica, ka māsa arī. Tur ir skaistas pudeles un bundžas, un citas drazas, kas nav tik skaistas. Tur ir baigi forši, kājas ieslīd starp papīriem un vecām atsperēm, un tu vairs neredzi savas kurpes, un ir baigi interesanti, kad tu atkal tās ieraugi, aplipušas ar dubļiem un drupačām. Mēs aizbrienam garām visai šķūņu rindai, un, kad esam laukā uz ceļa, es lepni paskatos uz Dārtu, jo pie viņas mājas TĀDAS misenes nav. Viņa apmierināta pamāj ar galvu.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2010\/2011"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Vēl apstādinu Dārtu pagalma vidū un rādu, ko esmu sazīmējusi ar krītiņiem uz asfalta. Dzeltenas princeses ar zaļiem matiem un rozā kleitām. Kad ar Dārtu esam pie durvīm, man mazliet jāpastiepjas, lai ietrāpītu atslēgas caurumā, jo tas ir augstāk nekā citām parastajām durvīm. Kad atslēdzu arī otras durvis, mēs neesam pamanītas. Uz dīvāna māsa bučojas ar Aleksi. Hi! Hi! Mēs ar Dārtu saskatāmies, un esam jau pamanītas. Tikai nesaki mammai! Nesaki! Labi? Apsoli? Aleksis iedod mums ar Dārtu kokakolas bundžiņu. Hi! Hi! Mēs nosolāmies klusēt. Kad viņi iet ārā, es vēl paspēju nobļaut pakaļ, ka nākamreiz viņa mani ņems līdzi. Māsa neko neatbild. Mums mājās ir auksti, jo nav radiatoru. Mums ir krāsns virtuvē un iemūrētais katls, kur var dabūt siltu ūdeni, kad jāmazgājas. Mums nav vannas, bet virtuves stūrī ir četras plastmasas bļodas katra savā krāsā — katram sava. Krānā ir tikai aukstais ūdens. Mēs izmantojam virtuvi arī par vannas istabu. Te stāv arī Foras bļoda, un uz durvju roktura karājas viņas siksniņa. Mums ir arī gāzes plīts ar diviem riņķiem, bet mēs to reti izmantojam, jo gāze ir dārga un, kad balons beidzas, jauns ir jāgaida nedēļu. Mums ir elektriskā tējkanna, kur mamma vāra olas un cīsiņus, un zupu.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2010\/2011"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Dārta iekārtojas uz mammas dīvāna, es uz māsas kušetes. Mēs spēlējamies ar manām lellēm.\nKad eju pie Dārtas, viņa man dod savējās. Kad katra esam iekārtojušas leļļu mājas, tad ejam ciemos\nviena pie otras. Bet tas nav ilgi, jo Dārtai sešos jābūt mājās. Es viņu pavadu līdz trolejbusa pieturai,\ntad viņa nedaudz pavada mani, tad es atkal viņu līdz pieturai, un šķiramies. Es skrienu mājās, jo\nap septiņiem nāk mamma. Kopš tētis man iemācīja pazīt pulksteņa ciparnīcu, es vienmēr zinu,\nkad jāsāk gaidīt mammu. Es ieskrienu iekšā, atrauju virtuves logu un uzguļos uz palodzes, nolieku\nblakus ķebli, pasaucu Foru, uzstutēju viņu uz tā un lieku gaidīt kopā ar mani. Kad viņai purnā iepūš\nvējš, viņa samiedz acis un nošķaudās kā īsta dāma. Tiklīdz krustojumā iedegas zaļā gaisma, es\nsaspringstu, bet mamma nenāk, kamēr deg sarkanais, es pētu pretējo māju, kad zaļais, tad atkal\nskatos, vai mamma neiznirst no stūra.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2010\/2011"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Kāds slēdz durvis! Nevar būt, ka es viņu nepamanīju!\nEs skrienu pie durvīm. Tā ir māsa. Viņa atnāca ātrāk, lai paspētu pārbaudīt, vai es tiešām neko\nneteikšu mammai par viņu un Aleksi. Ne-e, neteikšu. Apsolu. Nu, tu man skaties, sīkā! Neteikšu, bet\ntu paņemsi mani līdzi nākamreiz? Ko?! Nezinu, nu labi, paņemšu. Atkal kāds slēdz durvis. Mamma!\nMaaaaaaammmmm! Čau, meitukiņ! — viņa man saka. Kā labi gāja? Labi! Mani pārņem tāda laime,\nka viņa beidzot ir mājās, ka man gribas uzdāvināt viņai māmiņdienas apsveikumu jau tūlīt, bet es\nsaņemu sevi rokās. Vēl jāpaciešas. Rīt vēl ne, bet dienā pēc rītdienas es varēšu viņai to iedot.\nMana kartīte noteikti sanākusi labāka nekā Dārtai. Viņa gan teica, ka viņai savējā patīkot labāk, bet\nmanējā tik un tā ir smukāka, jo man ir vislabākā mamma",
+  "KLASE": 12,
+  "MACIBU_GADS": "2010\/2011"
+ },
+ {
+  "TEKSTA_FRAGMENTS": " Izvediet ārā Foru, kamēr taisīšu vakariņas! — saka mamma. Es norauju no virtuves durvju\nroktura siksniņu, tā noskan, un Fora jau saprot, bet es viņu mudinu vēl vairāk. Nāc, iesim! Ārā!\nĀrā! Iesim ārā! Foras nagi skrapst pret grīdu, viņa pinas man pa kājām un nevar nostāvēt mierā,\nlai uzliktu siksnu. Kad attaisu durvis, viņa rauj mani lejā pa trepēm, atsprāgst ārdurvis, un esam jau\nārā. Māsa novirza mūs uz šķūnīšu pusi, kad esam ārā no jebkāda vērotāja redzes lauka, viņa izvelk\nno kabatas samīcījušos cigareti un aizsmēķē. Es pateikšu mammai. Pamēģini tikai! Es tevi nekur\nneņemšu līdzi! Tas man aizcērt muti, un es, dusmās sakniebusi lūpas, klusēju. [..]\nMēs ejam drusku tālāk, tur gar dārziņu žogu līdz jaunajam ceļam. Viņi nesen uzlikuši jaunu\nasfaltu, lai var piebraukt pie SWH. Fora iebrien lupīnu lapās un ošņājas. Mēs ejam tālāk, un māsa\nman prasa: A tu pie tēta iesi ciemos? Jā, rītā laikam. Nu, tad iedod viņam šito, viņa saka un iedod\nlapeli. Es zinu, ka nevar skatīties, ielieku kabatā ar domu, ka vēlāk izlasīšu, un viņa zina, ka es lasīšu.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2010\/2011"
+ },
+ {
+  "TEKSTA_FRAGMENTS": ". Es pamanu viņu skrienam pāri krustojumam. Fora, nāc šurp!!!\nViņa sadzird mani, pagriežas un bāc! Nēēēē! Mašīna tieši viņai pāri, tieši virsū un tālāk prom. Viņa\nguļ krustojuma vidū. Mēs sastingstam. Māsa skrien uz mājām. Es pakaļ, vēl tikai ar acs kaktiņu\nredzu, kā tantiņa paņem viņu aiz priekšķepām kā beigtu un nones malā uz trotuāra. Es skrienu pakaļ\nmāsai. Viņa ieskrien mājā, smagi aizcērtas durvis, [..], tad atsitas atkal vaļā un ar mazāku troksni\naizkrīt pavisam. Man arī jātiek mājās. Ahha ahha ahha, es elsojot skrienu pāri pagalmam. Un pēkšņi\nkrītu. Es neko nejūtu, bet, kad pieceļos un ieraugu asiņaino celi, man sagriežas visa pasaule putrā\nar asinīm un smilšu kunkuļiem brūcē. Viss melns, un sarkani riņķi pamīšus ar baltiem plankumiem\ndzirkstī man acīs. Es esmu iekšā. Raudas un elsas. Un suns beigts. Roka uz koka margas, tā\nir lipīga un veca, vienmēr jāmazgā rokas, kad esmu pie tās turējusies. Es vēl neesmu tikusi līdz\ndurvīm, kad man pretī nesas mamma ar māsu un vecu segu padusē. Lai skrien! Lai! Es arī nomiršu.\nNomiršu! Un mauroju pa visu koridoru. [..] Es aiztaisu šleperi. Tek lielas lāses no acīm un ceļgala.\nEs uzritinos uz ķebļa pie virtuves loga.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2010\/2011"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Viņas ienes nelaimīgo saini. Nervu gali zem ādas kut, un šķiet, ka āda kustas, kaut kur plūst, iet projām. Atceros tikai pantenola baltās putas uz ceļgala un radību tīstoklī, kurai vēl lēni cilājas sāni, un tad gaisma izdziest. Es atveru acis. Viss sastindzis kluss. Dzirdu sevi elpojam. Es iedomājos, ka nekad nepievēršu uzmanību tam, ka elpoju, tas notiek pats no sevis. Es aizmirstu par gaisu, kas jāievelk un jāizdveš. Vai tiešām, kad aizmirstu, tas notiek pats no sevis? Tas notiek. Tas notiek. Tas notiek. Kā lēnas svītras, ko intervāliski ievelku nāsīs, un tad tās dodas pašas savā gaitā, savā kustībā, savā satiksmē tur iekšā un tur ārā. Atkal intervāls. Iekšā. Ārā. Es guļu uz sāna. [..] Kad pamodos, labā sejas puse bija nogulēta. [..] Paldies Dievam! Durvis arī priecīgas, ka tās slēdz. Šlepera atspere saraujas, izstiepjas, pagriežas un ir vaļā, un ir labi. Vairs neesmu viena. Es paliecos uz priekšu un gar skapja stūri redzu, kā mamma meklē gaismas slēdzi.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2010\/2011"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Meitukiņ! Vai tu... es nedzirdu, ko viņa tur vēl saka. Es redzu, ka aiz mammas nāk māsa un\nviņai klēpī mūsu melnais suns, kam tagad uzradusies balta kāja. Fora! Fora dzīva! Viņas noliek\nForeli zemē uz segas, es viņai tūlīt pretī, uz ceļgaliem, au!, zemē, deguns degunam pretī. [..]\nNāc ēst, mamma mani sauc.\nMēs sēžam virtuvē. Vaska drāna, izbalējusi un sagraizīta, ir galda otrā āda, pielipusi pie\nvirsmas, tā nāk nost kopā ar lielām koka skaidām, tāpēc to neviens necilā. Kur tā sagraizīta, pušumos\nsabirušas drupačas, ko nekad nevar izslaucīt ar lupatu. Suns parasti mums danco apkārt, kad ēdam,\nnekaunīgi skatās acīs un laiž slienas. Tagad viņa viena sēž istabā, jo nevar atklibot ar savu ģipša\nkāju, bet mums ir cepta kartupeļu putra ar mērci, ar lielām glumu sīpolu ceptajām ķeskām. Mamma\nir ļoti nogurusi, es redzu. Es atdalu speķus no gaļas gabaliņiem, salieku saujā un prom uz istabu.\nNometu priekšā Forai, un tūliņ atpakaļ uz virtuvi.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2010\/2011"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Mēs ēdam lēni kā jau nogurušas. Māsai jāmazgā\ntrauki, man jāslauka. Mamma tikmēr raksta atskaites darbam. Mammuci, es viņai apķēros ap kaklu,\nman zeķbiksīte izira, man nav ko vilkt rītā. Labi, noliec tepat, kamēr tu mazgāsies, es sašūšu. Bet\nvēl jau multene, tūlīt sāksies. Viņa mani notur aiz rokas, kad gribu skriet pie televizora, šodien ne,\nšodien nebūs, tur rāda prezidentu no Amerikas, kas atbraucis pie mums ciemos. Multenes vietā.\nEs izplešu acis. Mammucis saguris. Es tevi ļoti, ļoti, ļoti mīlu, sažmiedzu ­viņu savās bērna rokās.\nViņa mani ievelk sev klēpī un mirkli šūpo, kad caur viņas padusi redzu, kā māsa uz to noskatās,\natbrīvojos un eju mazgāties. [..]\nKad esmu noslaucījusies un mugurā naktskrekls, izskaloju bļodu un nolieku vietā, zem\nmammas baltās. Ar plikām kājām aizskrienu uz istabu, uzrauju kājās mīkstās zeķītes. Jāriktējas\nuz gulēšanu. No sava izlaižamā krēsla noņemu mīkstos spilvenus un gultas pārklāju. Saklāju savu\ngultu, palienu zem segas un, kamēr māsa vēl nav aizgājusi uz virtuvi, runājos ar Foru, lai neaizmigtu\nun neaizmirstu par lapiņu. Mammuci, nevajag lāpīt zeķbikses, rītā taču sestdiena.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2010\/2011"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Jā, viņai lauzta kājiņa, bet gan jau\ndrīz sadzīs. Labi, tagad čuči! Kad viņa atkal iegrimusi savās atskaitēs, es aizsniedzos līdz biksēm un\natrodu lapiņu. Pagriežos ar muguru un loku vaļā lēni, lai papīrs nečaukst. Kad esmu tikusi klāt pie\nlapiņas satura, mani pārņem milzīga vilšanās, divas rindiņas, un abas krievu valodā, neko nesaprotu\nno tiem ķeburiem. Tētis ir krievs, viņš nav dzērājs, viņš vispār nedzer. Kad piedzima māsa, viņu\nsūtīja uz krievu skolu, bet mani uz latviešu. Mēs vienmēr runājam latviski, es tikai dažreiz smejos par\nmāsu, kad viņa saka gūlta vai tūlks. Saņemu lapiņu saujā, salieku rokas zem spilvena un guļu. [..]\nAttaisu acis. [..] Saģērbjos, saloku atpakaļ savu izlaižamo krēslu, uzklāju pārvalku, salieku\nmīkstos spilvenus. Atnāk mammucis: nomazgā acis, un tad tev būs jāiznes ārā Fora! Jāiznes? Nu\nja, viņa taču pati nevarēs aiziet. Ūdens ir ledains, acis uzreiz atveras plašāk, no kaktiņiem izknibinu\nmiegu un esmu gatava iet. Paņemu viņu uz rokām. Mamma attaisa man durvis, trepēs nevienu\nnesatieku, kad esam pāri pagalmam, es viņu nolaižu zemē. Fora kādu brītiņu stāv, tad nošķaudās\nun uz trijām ķepām palec gabaliņu tālāk",
+  "KLASE": 12,
+  "MACIBU_GADS": "2010\/2011"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Mammucis tikām jau sataisījis man brokastis, biezpiens, virsū krējums, tad cukurs un kanēlis.\nKūka. Tu nevari čammāties, viņa man saka, tētis tevi gaida pusdivpadsmitos. [..]\nKad esmu pie tēta, iedodu viņam saņurcītu lapeli, ko rakstījusi māsa. Viņš ātri izlasa. Tēti,\nkas tur rakstīts? Nekas, kad izaugsi, sapratīsi. Viņš ieslēdz kompjūteru, un es kādu stundu spēlēju\nspēlītes, tad vecmāmiņa sauc mūs pusdienās. Kamēr viņa liek ēdienu šķīvjos, es pasaucu tēti\nmaliņā un čukstus prasu atļauju piezvanīt. Kam tu zvanīsi? Dārtai. Labi, tikai nerunā ilgi. Apsolu.\nDārta? Čau! Es esmu pie tēta. Es varu vēlāk aiziet pie tevis? Labi, pēc kādas stundas. Labi. Atā!\nMums mājās nav telefona.\nEs ātri paēdu, atsakos no papildporcijas, jo nav pārāk garšīgi. Lēnā garā taisos uz promiešanu.\nTētis man vēl iedod aploksnīti un piesaka atdot to māsai. Tagad laikam nedrīkst skatīties, bet man\nnoteikti jāredz, kas tur ir iekšā. Tētis vēl prasa, ko darījāt skolā. Ai, neko. Taisījām darbmācības\nstundā apsveikumu māmiņdienā. Jā? Jā, man vissmukākais sanāca. Rītā dāvināšu mammai. Labi,\natā! Tad tiekamies pēc divām nedēļām? [",
+  "KLASE": 12,
+  "MACIBU_GADS": "2010\/2011"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Es skrienu uz trolejbusu. Mīņājos pieturā. Kad esmu iekāpusi transportā, žigli izvelku aploksni, mani pārņem kārtējā vilšanās, aploksne ir aizlīmēta, bet es to paceļu pret gaismu un redzu iekšā skaistu zaļu pieclatnieku. Hi! Nākamajā man jākāpj ārā. Skrienu pie Dārtas. Viņa dzīvo ceturtajā stāvā, un viņai nav lifta. Aizelsusies zvanu pie viņas durvīm un, kad viņa attaisa, saku, lai nāk ārā, man ir krītiņi. Viņa atstāj durvis pusvirus, pasaka savai mammai, ka būsim tepat ārā, un tad mēs laižam lejā pa trepēm un ejam uz gludo asfaltu. Manas princeses vienmēr sanāk labāk nekā Dārtai, tāpat kā apsveikums mammai. Rītā! Jau rītā es varēšu viņai to uzdāvināt. Mēs esam galīgi aizrāvušās, bikses vienos krīta putekļos, tāpat kā pirksti un deguni. Dārta man prasa, cikos man jābūt mājās. Precīzi četros. Nevar kavēt, mamma gaida. Mēs nezinām, cik ir pulkstenis. Bet Dārta pajautā savai kaimiņienei, kas atbild, ka ir bez piecām četri. Jau? Man jāskrien! Man jāskrien! Es nekārtīgi sametu krītiņus kastē, nepamanīdama, ka viens vēl paliek Dārtai rokās, un skrienu projām. Līdz pirmdienai! — Dārta man uzsauc, palikdama pie kājām manām skaistajām krītiņu figūrām. Es izskrienu ārā no pagalma un pa trotuāru gar ielas malu, sacenšoties ar garām braucošo trolejbusu, skrienu mājās, skaitīdama noskrietās ceļa baltās svītras. Atrauju ārdurvis, [..], skrienu augšā pa trepēm, roka pieķeras pie lipīgās koka margas, uztraukumā nevaru ietrāpīt atslēgu caurumā, bet, kad esmu iekšā, pulkstenis rāda četri un gandrīz desmit minūtes. Tu jau mājās? — prasa mamma. Labi, tagad varam visi iziet pastaigāties un ieēst saldējumu. Es tevi mīlu, mammuci! — apķeros viņai apkārt un sažņaudzu viņu savās bērna rokās.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2010\/2011"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Tas bija garš ceļojums, bet ļoti interesants. Īkstīte jutās laimīga, jo no krupjiem\nvairs nebija jābaidās, un brauciens bija tik jauks! Saule apspīdēja ūdeni, tas\nlaistījās tīrā zeltā un sudrabā. Visu vasaru Īkstīte pavadīja lielā pļavā. Viņa nopina\nno smilgām gultiņu un pakāra zem prāvas dadža lapas. Tā viņa bija pasargāta no\nvēja un lietus. Viņa pārtika no ziedu medus un rasas lāsēm, kas ik rītu sakrājās uz\nlapām.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2011\/2012"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Pagāja vasara un rudens, pienāca barga un auksta ziema. Putni, kas tik\nlīksmi bija dziedājuši, aizlaidās projām. Lielā dadža lapa, zem kuras Īkstīte mājoja,\nsačokurojās un pierāvās pie dzeltenā, savītušā kāta. Īkstīte briesmīgi sala; drēbes\nviņai bija noplīsušas, pati sīka. Viņa zināja, ka nosals; nekas cits nebija gaidāms.\nMeža malā pletās milzīgs tīrums. Labība sen jau bija novākta, tikai kaili, sausi\nrugāji rēgojās uz sasalušās zemes. Īkstītei rugāji šķita liels mežs. Viņa drebinājās\nsalā un pūlējās tikt tiem cauri. Tā viņa nonāca pie lauku peles namdurvīm. Pelei\ntumšā pazemē bija mazs namiņš, un viņa tur dzīvoja gluži omulīgi: istaba bija silta,\nvirtuve ērta un pieliekamais pilns ar graudiem. Nabaga Īkstīte nostājās uz sliekšņa\nun lūdza mazu gabaliņu miežu grauda, jo veselas divas dienas nebija ne kumosiņa baudījusi.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2011\/2012"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "– Nabaga bērns! – teica lauku pele, jo bija patiešām lādzīga un labsirdīga\nvecīte. – Nāc manā siltajā istabā, es tevi pamielošu!\nPelei Īkstīte iepatikās, un viņa sacīja:\n– Ja vēlies, vari palikt visu ziemu pie manis. Tev tikai jātur mana istaba tīra un\nspodra un jāstāsta man pasakas, jo tās es labprāt klausos.\nĪkstīte darīja visu, ko pele lika, un viņai nu klājās gluži labi.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2011\/2012"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Reiz dzīvoja sieviete, kurai nebija bērnu. Burve iedeva viņai mieža graudu un teica:\n– Ieliec to puķu podā, tad pēc laiciņa pieredzēsi brīnumus!\nSieviete iestādīja graudu puķu podā. Necik ilgi nebija jāgaida, kad tur izauga skaista puķe. – Cik\njauka puķe! – sieviete noteica un noskūpstīja sārtdzelteno pumpuru. Tas pēkšņi atsprāga vaļā, bet tam\nvidū sēdēja maza meitenīte, sīciņa un smalciņa, tikko pusīkšķa garumā, tāpēc audžumāte nosauca viņu\npar Īkstīti.\nĪkstītei ierīkoja guļvietu glītā, nolakotā rieksta čaulā.\nReiz naktī pa saplīsušo loga rūti ierāpās vecs krupis. Viņš bija neglīts, liels un slapjš un uzlēca taisni\nuz galda, kur Īkstīte gulēja.\n– Tā būtu tīri laba sieva manam dēlam! – krupis noteica, paņēma rieksta čaulu ar Īkstīti un izlēca\natpakaļ dārzā.\nUpē auga daudz ūdensrožu ar platām, zaļām lapām. Krupis piepeldēja pie tālākās lapas un uzlika\ntur Īkstīti ar visu gultiņu.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2011\/2012"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Nabaga meitenīte pamodās agri, jo viņai bija vēsi. Ieraudzījusi, kur atrodas, viņa sāka skaļi raudāt,\njo visapkārt lapai bija dziļš ūdens un krastu viņa nevarēja sasniegt. Tad krupis ar neglīto dēlu piepeldēja\npie Īkstītes, lai aiznestu viņas gultiņu uz goda istabu.\nViņi paņēma glīto gultiņu un aizpeldēja, bet Īkstīte palika viena uz ūdensrozes lapas un raudāja,\njo negribēja dzīvot pie vecā, pretīgā krupja un precēt viņa riebīgo dēlu. Zivtiņām kļuva žēl piemīlīgās\nmeitenītes. Zivtiņas salasījās pie zaļās lapas un pārgrauza kātu. Lapa ar Īkstīti aizpeldēja lejup pa straumi –\ntālu, tālu, kur krupis to vairs nevarēja panākt.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2011\/2012"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Gaujas Nacionālajā parkā par zvērkopi biju nostrādājusi vairāk nekā 28 gadus un izaudzinājusi visdažādākos dzīvnieku mazuļus: stirnēnus, lapsēnus, alnēnus un lācēnus. Ar ūdrēniem nekādu darīšanu man līdz šim nebija, un es jau sen sapņoju audzināt ūdru. Augustā mans sapnis piepildījās. Pie Ķūķu krācēm atradām ūdrēnu. Tā kā dzīvnieciņš viens nespētu izdzīvot, paņēmu viņu uz savu māju, jo tas taču ir ierasti, ka mājās dzīvo kāds meža iemītnieks! Ūdrēnam vēlāk devu vārdu Ķūķis. Vienā istabas stūrī izveidoju Ķūķim jaunu mājvietu – norobežotu teritoriju, kur ieklāju segas, ieliku vecas, siltas jakas, kurās ūdrēnam ielīst, un ūdens trauciņu. Mani ilgi turpināja izbrīnīt ūdrēna brīvā, drošā uzvedība. Parasti savvaļas dzīvnieku mazuļiem tomēr nepieciešams kāds laiks, kamēr tas pierod pie cilvēka, pieņem to kā savu draugu un „mammu”. Ķūķis omulīgi gulēja klēpī un acīmredzami priecājās par šo procesu jau kopš pirmās dienas.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2011\/2012"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Kad Ķūķis negulēja kāda klēpī, viņš labprāt ierakās mīkstajos tekstilizstrādājumos. Izgulējies, klusi runādamies savā ūdrēna valodā (nemāku aprakstīt šīs skaņas, bet izklausījās ļoti mīļi un maigi), iznāca paskatīties, kas jauns apkārt. Ēst no pudelītes Ķūķis sāka pēc aptuveni pusotras diennakts, kad paņēmu viņu rokās vēl saldi aizmigušu. Īsti nepamodies, pa pusei būdams sapņu pasaulē, viņš cītīgi sāka ēst. Arī turpmāk Ķūķis vienmēr labāk ēda pusaizmidzis, jo tad, kad bija pārāk jautrā prātā un aktīvi spēlējās, nekāda ēšana nesanāca. Istabas iežogoto daļu viņš ātri atzina par savu personīgo telpu un iesākumā uzbruka visām jaunajām lietām, kas tur uzradās, piemēram, sūnu čupiņai vai spēļmantiņai. Tas izskatījās šādi: ūdrēns stingri nostājās uz visām četrām kājām, šņāca un taisīja tādus kā īsus palēcienus iedomātā briesmoņa virzienā. Tad lielā dūša Ķūķēnu pameta un viņš glābās bēgot, ielienot zem segas vai jakās. Mammai (tas ir – man) bija jāpieradina audžubērns pie visa, kas tam tobrīd bija jauns, svešs un neierasts, tieši kā ūdru mammai dabā.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2011\/2012"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Piektajā dienā, ko Ķūķis bija pavadījis pie manis, viņš sev atklāja ūdens pasauli. Mazā dzeramtrauciņā ūdens bija visu laiku, un satrakojies ūdrēns pēkšņi izdomāja, ka viņam taču ūdens patīk! Palēkdamies gaisā, Ķūķis ar galvu pa priekšu ienira līdz pusei (viss vienkārši neietilpa) bļodā, kur tūlīt cītīgi mēģināja ar priekšķepām ierakties dziļāk. Ķūķis nekad nenopurinājās pēc ūdens peldēm, tekošs un pilošs devās savās gaitās, atstājot aiz sevis slapju sliedi. Dažreiz mēģināju viņu pēc peldes noslaucīt ar dvieli, bet šo procesu Ķūķis tūliņ uztvēra kā kārtējo rotaļu un laimīgs ļāvās, lai viņu slauka un burza, bet pēc tam tūlīt atkal metās ūdenī un ātri skrēja atpakaļ – slauki nu mani atkal! Kad uznāca vēlēšanās pagulēt, Ķūķis mēdza palīst zem segas vai kāda drēbes gabala. Guļot viņam kļuva karsti, un tad miegā viņš lēnītēm līda laukā, līdz beigās parasti gulēja uz muguras – katra kāja uz savu pusi, resnais puncis uz augšu. Paldies tev, Ķūķi! Neviens cits dzīvnieks man mūžā nav sniedzis tik daudz neviltota prieka!",
+  "KLASE": 6,
+  "MACIBU_GADS": "2011\/2012"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Par zvērkopi biju nostrādājusi vairāk nekā 28 gadus un izaudzinājusi visdažādākos dzīvnieku mazuļus: stirnēnus, lapsēnus, alnēnus un lācēnus. Ūdrēnus nekad nebiju audzinājusi, bet ļoti vēlējos kādreiz to izdarīt. Augustā vēlēšanās piepildījās – manās mājās nokļuva mežā pamests ūdrēns, ko bija atraduši tūristi pie Ķūķu krācēm, tāpēc jaunais mājas iemītnieks tika nosaukts par Ķūķi. Septembra pirmajā dienā nolēmu, ka ūdrēns ir pietiekami paaudzies, lai laistu to pastaigās pa visu māju. Iepriekš Ķūķis dzīvoja norobežotā teritorijā vienā istabas stūrī. Izveidoju nelielu vaļēju spraugu nožogojuma pusē. Protams, no jauninājuma viņa mājvietā Ķūķis nobijās un iekunkuļojās zem segām, bet interese bija liela. Istaba tā pati vien bija, smaržas pazīstamas, tāpēc jau pēc īsa brīža ūdrēns pielīda pie spraugas un uzmanīgi skatījās laukā. Tad viņš izdomāja ļoti oriģinālu veidu, kā noskaidrot, cik droši ir ārpasaulē un kādas briesmas tur varētu draudēt. Viņš ņēma zobos pa vienai visas savas mīļākās spēļmantiņas, pienesa pie spraugas un meta ārā, tas nozīmēja – sūtīja izlūkos. Pats gulēja iekšpusē un modri vēroja, kas notiks. Kad ārpusē jau bija vesela mantu kaudze un neviens par tām neizrādīja interesi un neuzbruka, Ķūķis saņēma dūšu un devās savā pirmajā ekspedīcijā pa visu istabu.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2011\/2012"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Vēl pēc nedēļas, kad Ķūķim pašam apnika spēlēties ar kādu no mantām, viņš bija ar mieru dalīties tajā arī ar citiem, piemēram, ar mani – savu audžumammu. Ūdrēns varēja pienākt un iemest klēpī kādu savu rotaļlietu – paspēlējies arī tu! Tas, ka mantas visbiežāk bija slapjas un netīras, nekas, galvenais ir labā griba un dāsnā sirds. Pavisam drīz ūdrēns atklāja arī trepes uz otro stāvu, kurā vēl bija divas izpētāmas telpas, daudz mīksto mantiņu, ko nočiept, liels puķupods ar smiltīm un daudz citu labumu. Kāpt pa trepēm augšup un lejup viņš prata, tā vien šķita, ka ūdri ar šo māku jau piedzimst (piemēram, lācēni tādā pašā vecumā labi tika uz augšu, bet bija lielas problēmas tikt atkal lejā).",
+  "KLASE": 6,
+  "MACIBU_GADS": "2011\/2012"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Mājas kaķi istabā laisti netika, kopš te dzīvoja ūdrēns. Vienreiz kaķene Bebē ātri iešmauca un tūlīt slēpās otrajā stāvā. Viņai ļoti nepaveicās, jo tieši kāpņu vidū saskrējās ar Ķūķi, kurš šņākdams metās kaķenei virsū. Iebrucējs manā teritorijā! Bebē pārbijusies izmuka, bet Ķūķis vēl ilgi, cītīgi ošņādams grīdu, pārbaudīja visu māju, vai svešiniece tomēr kaut kur nav noslēpusies. Istabā vēl bija izveidojies tāds rotaļāšanās veids – Ķūķis, kaut kur iekodies ar zobiem (dvielī, drēbes gabalā vai čībā, kas, protams, bija uzauta kāda kājā), ļāvās, lai viņu velk pa grīdu. Tādās reizēs viss ūdrēna ķermenis bija pilnīgi ļengans, kājas brīvi karājās, darbojās vienīgi zobi. Nekur Ķūķis nevarēja noskatīties kaut ko tādu, un arī savvaļā dzīvojošiem ūdriem šāda rotaļāšanās nav raksturīga. Paldies tev, Ķūķi! Neviens cits dzīvnieks man mūžā nav sniedzis tik daudz neviltota prieka!",
+  "KLASE": 6,
+  "MACIBU_GADS": "2011\/2012"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Mūziķis Renārs Kaupers ar domubiedriem turpina Imanta Ziedoņa leģendārās Koku grupas tradīcijas – apbraukā Latviju ar grābekli un lāpstu rokā un uz mazām, bet būtiskām iniciatīvām aicina arī citus. Kādā Rīgas kafejnīcā 2000. gadā sarunājas Imants Ziedonis un Māra Zālīte. Imants Ziedonis: „Kauperītis ir vienīgais, kas var iznest tautasdziesmu. Kad viņš dzied tautasdziesmu, tā pēkšņi atkal ir. Kad viņš dzied, tad uzreiz viņam tic visi un dzied līdzi to tautasdziesmu, citādi viņi nedziedātu to tautasdziesmu.” Māras Zālītes saruna ar Imantu Ziedoni aprakstīta grāmatā To mēs nezinām. Imants Ziedonis un Renārs Kaupers toreiz vēl nebija iepazinušies. Toreiz Ziedonim pat sapņos nerādījās, ka „tas feinais zēns”, „tas jefiņš”, „Kauperītis” 2009. gadā sapulcēs jaunus, iedvesmas pilnus cilvēkus un taps Mazā kavalērija – domubiedru grupa, kas apņēmusies sakopt Latvijas aizaugušos kaktus un stūrīšus un iedvesmot līdzīgiem darbiem mūs visus citus.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2011\/2012"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "2009. gada 28. aprīlī kavalēristi, kuru vidū ir mūziķi, studenti, pasniedzēji, baņķieri un uzņēmēji, sakārtoja katrs savus darbus tā, lai otrdiena būtu brīva. Gumijniekiem kājās, grābekļiem, lāpstām rokās viņi sēdās busiņā un devās uz pirmo talku. Uz Bērzpili Latgalē sakopt Dziesmu svētku kalniņu. Tur viņus jau gaidīja palīgi – pagasta skolēni un skolotāji. „Tās dienas vakarā mēs skatījāmies cits uz citu mirdzošām acīm un nevarējām noticēt, ka tieši tā, kā bijām plānojuši, viss arī notika,” atceras Renārs. Sekoja vēl viena otrdiena, un vēl. Ik pēc trim nedēļām. Tikai trešajā reizē viņi, busiņam klusi dūcot uz lielceļa, apmulsuši saskatījās un attapās – paklau, bet tas taču ir tieši tas pats, ko septiņdesmitajos, astoņdesmitajos, vēl deviņdesmitajos gados darīja Koku grupa jeb dagisti – Dižkoku atbrīvošanas grupa (DAG). Ziedonis teica – daģi. No 1976. gada līdz 1997. gadam Imants Ziedonis ar domubiedriem, kuru vidū bija tautā mīlēti mākslinieki, zinātnieki, arī studenti, apbraukāja Latviju, izkopa aizaugušās birzis, uzkalniņus, ezermalas. Atbrīvoja no drazām un pinekļiem Latvijas dižkokus. Uzstādīja piemiņas zīmes, ko akmenī izkala viens no grupas, tēlnieks Vilnis Titāns.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2011\/2012"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Vasaras viducī kavalēristi un dagisti pirmo reizi satikās. Saņēma uzaicinājumu no Imanta Ziedoņa atbraukt ciemos. Tas bija emocionāls brīdis. Smaidīgi un mazliet kautrēdamies sasēdās vieni otriem pretī gar istabas malām. Sākotnēji Imants uz mums skatījās ar aizdomām.Ar katru tikšanās reizi viņš kļuva... priecīgāks nav tas vārds. Gandarīts par to, ka ir kādi dullie jaunie, kuri grib viņa lietu turpināt. Agrā pavasarī dzimusī ideja – darīt kaut ko Latvijas labā – reālas aprises ieguva dažu mēnešu laikā. Nosvinot Māru dienu 2009. gada martā, Renārs Kaupers, Andris Čeksters, Māra UpmaneHolšteina un citi jauni cilvēki sanāca kopā Prāta vētras birojā Rīgas centrā, lai izrunātu, ar ko sākt. Kavalēristi nolēma, ka sāks ar vistuvāko – pašu dzimtajām vietām. Ar viņiem kopā no pirmsākumiem bija vairāki jaunie mūziķi: Māra Upmane-Holšteina no grupas Astro’n’out, Goran Gora, Jānis Strapcāns no h2o un Kārlis Kazāks, arī Latvijas Tirdzniecības un rūpniecības kameras priekšsēdētāja Žaneta Jaunzeme-Grende ar vīru Antu Grendi. Nedaudz vēlāk pievienojās būvuzņēmējs Māris Saukāns.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2011\/2012"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Koku grupai bijis citādi – tie allaž talkās brauca nedēļas nogalēs. Kavalēristi gan lēmuši – brīvdienas lai paliek ģimenēm, brauks talkās otrdienās! Intervijā ieminos Renāram, ka koncertos mūziķi droši vien cilvēkus uztver drīzāk kā anonīmu masu. Individuālumu, cilvēka dvēseli jau no skatuves neredz. Renārs piekrīt. Ar kavalēriju pa Latviju braukājot, beidzot cilvēkus ieraudzījis sejā – gan tiešā, gan pārnestā nozīmē. Katra dvēseli. Apjautu, ka Latvija ir tik skaista un sakopta. Galu galā, viss cēlies tikai no viena Ziedoņa citāta: „Latvija ir brīnumskaista zeme, tikai skaistajam jāpalīdz parādīties.” „Tas, ko mēs padarām, ir kaut kas maziņš: sakopjam kalniņu, parkā izcērtam krūmus, salasām akmeņus no lauka. Dažreiz tie darbiņi ir utopiski. Protams, zāle atkal aizaugs, akmeņi parādīsies. To pašu darīja Imanta Koku grupa: viņi brauca nekurienes vidū, kur neviens varbūt nekad kāju nespers, un atbrīvoja ozolus, cirta alkšņus. Pēc gada tas būs aizaudzis, bet tajā brīdī tiem cilvēkiem tas bija pats svarīgākais, kas ar viņiem var notikt.”",
+  "KLASE": 9,
+  "MACIBU_GADS": "2011\/2012"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Kad 1976. gadā Ziedonis nodibināja savu Dižkoku atbrīvošanas grupu, tā bija kā spļāviens sejā padomju nomenklatūrai. Aizliegt organizēt talkas, kopt dabu nevarēja, kaut bija skaidrs, ka Koku grupā apvienojušies radošie, brīvdomīgie prāti ne tikai raks, zāģēs un stādīs, bet arī dalīsies domās. Radīs idejas. ,,Ir stagnācijas laiks. Sastindzis savā bezizejā, sabiedriskajā lejupslīdē. Šeit tiek radīta alternatīva sabiedrība. Kas laižas lapās. Zūd kokos,” tā viena no dagistēm Māra Zālīte. „Vai mūsu grupa netika arī politiski novērota?” spriež Ziedonis grāmatā Tutepatās. „Gan jau tika, un bez tā neizpalika. Tāpēc zēniem, kas „mīlēja braukt ar muti”, tiku piesacījis sevišķi neaizrauties. Lai nedotu iemeslu mūsu skaisti iedibināto kopu aizliegt, izklīdināt.” Līdzīgu iniciatīvu Lietuvā likvidēja.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2011\/2012"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Koku grupa turējās kopā divdesmit vienu gadu. Sāka 1976. gadā, pabeidza 1997. Divdesmit viena gada laikā 198 talkas. Vakaros, kad darbi padarīti, viņi lasīja referātus. Diskutēja. Jokoja tā, ka vēdera muskuļi sāpēja vēl trīs dienas. Koku grupa tiekas joprojām. Brauc ciemos cits pie cita. Daudzi kļuvuši par tuviem draugiem uz mūžu. Vieno ideāli, kāda cilvēciska tuvības sajūta. Arī humora izjūta – tā dagistiem īpaša. Viens no grupas, dabas pieminekļu pētnieks Guntis Eniņš, atceras, kā radījuši tāpuru. Savajadzējies mīkstus sēžamos, kur vakaros pēc talkas atpūsties. Šūs spilventiņus ar ausīm! Kā tos sauks? Vai nu par tārpu, vai kāpuru – lai var salikt smukā rindā citu aiz cita. Kā tārpu. Dzejnieks Jānis Baltvilks teicis: tārps plus kāpurs – tad jau tāpurs! Seju tāpuram zīmēs mākslinieks Vitolds Kucins. Tālāk sprieduši par spilventiņu izmēru. Mērīt, cik liels katram dibens, šķitis nepieklājīgi. Nolēmuši, ka mērīs, cik liela katram demokrātija. Ēverģēlību Koku grupai netrūka. „Kā jau radoši cilvēki, visu ko izdomāja,” atceras Eniņš. Arī piramīdu: gulšanos vairākās kārtās citam virs cita.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2011\/2012"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Tiekoties ar Koku grupu, dagisti izstāstīja par piramīdu. Arī kavalēristi nolēma to izmēģināt. „Tas bija neapdomīgi, jo čupā gribēja piedalīties visi – kopā bijām divdesmit pieci cilvēki. Es biju čupas apakšā, arī Gorans un Kārlis Kazāks, un vēl Ants. Drosmīgi metāmies čupas apakšā. Virsū sagūlās nākamie. Tad nākamie. Kad sāka gulties ceturtā kārta, pēkšņi apjautu, ar kādu ārprātu mēs nodarbojamies. Man acu priekšā pavīdēja stadioni ar nospiestiem cilvēkiem. Un mēs to darām apzināti! Skatos, Gorans pieplacis pie zemes, sarkans, gandrīz neelpo. Saucu – varbūt pietiek? Man priekšā pielec smaidīga Astro’n’out Māriņa – vēl tikai divas kārtas! Pēc atgriešanās Rīgā nākamajā dienā es sazvanījos ar Kārli Kazāku. Viņš tikko no slimnīcas. Lauztas divas ribas. Izsmējāmies. Pareizāk sakot, smējos tikai es, jo Kārlis teica, ka nevarot pasmieties – viņam sāp. Kopš tā laika čupā vairs neesam gūlušies,” stāsta Kaupers. Šogad Mazā kavalērija plānos gājusi vēl tālāk – ar paša dzejnieka svētību, dažu kavalēristu inspirēts, ir nodibināts Imanta Ziedoņa fonds Viegli. „Tā vadlīnija ir – nest tālāk Imanta idejas, daiļradi, atbalstīt jaunos radošos un veicināt skaistā parādīšanos Latvijā,” skaidro Renārs. Šā gada februārī kavalēristi nolēma, ka būtu vērts sarīkot koncertu cilvēkiem, kuru idejas, darbu un finanses gribētos piesaistīt fondam.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2011\/2012"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Māra Zālīte domā – Ziedoņa un Kaupera līdzība slēpjas pozitīvajā programmā, kas viņiem ir, varam tikai minēt, no kādiem avotiem. Ceļi viņu priekšā šķiras. Tā ir izredzētība. Tagad Renārs kopā ar kavalēristiem lolo ideju par Ziedoņa muzeju. Par klasisku muzeju – „šeit viņš guļ, bet šeit ir viņa skapis” – nevarot būt ne runas. Renārs skaidro: „Imants saprot, ka neizbēgami radīsies kāds formējums – muzejs vai fonds, un labāk lai viņš piedalās tā veidošanā.” Ziedoņa paša projektētā un būvētā Murjāņu māja, kurai vigvama veidols un dvēsele, esot pilna brīnumainas radošas enerģijas. Ziedonis un Kantāne gribētu, lai tur pulcējas radoši cilvēki, brauc arī skolēni. Būtisko par Latviju, mājām Renārs apjautis pirms pāris nedēļām, ar Jāni Jubaltu sēžot bārā Teksasā, – uz Ameriku mūziķi bija devušies kārtot savas profesionālās lietas. „Labi vakarējām – rums, interesantas sarunas. Dega svecīte uz galda. Sagribējās paskatīties tuvāk uz liesmiņu. Paņemu to svecīti rokā un redzu, ka tā nemaz nav svecīte. Tā ir lampiņa, kas tur mirgo. Saku Jānim, paskaties – tāda ir visa Amerika! Skaista, gaiša no attāluma. Bet tuvumā – trūkst pamata, kas mums Latvijā ir. Tās vienkāršās svecītes, kas pa īstam pil uz tavas mājas galda.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2011\/2012"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Dziesmu svētku nebeidzamības pamatā ir sūrs un neatlaidīgs ikdienas darbs, kurā vairāk nekā 130 gados savu spēku, savas šaubas un varēšanu izbaudījis katrs latvietis. Svešzemju pētniekiem pagrūti saprast, kālab tauta, dzīvodama dažādu lielvaru apspiestībā, karu un izsūtījumu ārprātā, bēgļu gaitu bezcerībā, allaž domājusi par nākamajiem Dziesmu svētkiem, kuriem jāgatavojas solīti pa solītim, slīpējot dziedāšanas māku, šujot tērpus, krājot naudu un gaidot to brīdi, kad dziesmu spēks apskries visu Latviju vienā elpas vilcienā. Nu jau arī UNESCO līmenī atzīta mūsu, tāpat arī Lietuvas un Igaunijas Dziesmu svētku neatkārtojamība, piederība pasaules kultūras dārgumu krātuvei. [..] Dziesmu svētku vēsture ir tikpat plaša kā mūsu tautas vēsture no XIX gadsimta otrās puses līdz mūsu dienām. Pareizāk sakot, tā nav vēsture, kura ir aizgājusi pagātnes tumsā, jo Dziesmu svētku kustība turpinās un būs tikpat mūžīga kā Latvijas valsts",
+  "KLASE": 12,
+  "MACIBU_GADS": "2011\/2012"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Svarīgi definēt autentiskās tradīcijas, kas šos svētkus padara vienreizējus. Vēlams saglabāt galvenos Dziesmu svētku elementus – gājienu, Dziesmu karus, kopkoncertu, deju lieluzvedumu, Dziesmu svētku stilu –, kas ir tradīcijas un laikmeta specializētās mākslas sintēze. Pateicoties šai mijiedarbei, tie nav folkloras svētki vai tīrs šovs, bet gan – Dziesmu svētki. Šāda tūkstošos skaitļojamu amatierkoru kopēja muzicēšana vairāku stundu garā koncertā nekur citur pasaulē vairs nav dzirdama.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2011\/2012"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Kas būtībā ir koris? Tas ir tāds kā sabiedrības modelis miniatūrā. Tur ir dažādas izglītības, dažādi vecumi, tautības, intereses. Ko dara mūzika, kopā muzicēšana un koris? Koris spēj šos cilvēkus apvienot. Katram ir sava „valsts” – alts, soprāns, bass vai 32 divbalsīgi tenori –, un tā ir jānotur. Tev savējā ir jāiemācās perfekti – ir jānotur nevis tā, ka tu bļauj un nedzirdi nevienu apkārt, bet jānotur tā, ka tu dzirdi pārējos. To visu saliekot kopā, jānonāk līdz kopējam mērķim, kas teorētiski ir sabiedrības galvenais virzītājspēks. No bērnības muzicējot kopā, rodas pieredze, kā to darīt un kā spēt aizstāvēt savu viedokli un saklausīt citus, nepazaudējot savu domu.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2011\/2012"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Uzvelciet baltu kreklu un rakstiet no rītiem. Rakstiet jaunībā. Mīlestību līdz vecumam saglabā retais. Uzvelciet baltu kreklu un rociet zemi. Uzvelciet baltu kreklu un notīriet kurpes savai mātei. Uzvelciet baltu kreklu, kad jums nav viesu. Palieciet viens. Priecājieties par sevi. „Palicis viens, es jutos bezgala satraukts, it kā pēkšņi iekļuvis izcilu, slavenu, skaistu cilvēku sabiedrībā,” sacīja kāds gudrais. Uzvelciet baltu kreklu un rakstiet jaunībai. Viņa atnāk ar taureni bizē. Viņa ir soprāns vidusskolas korī. Un viņai ir baltas kurpes. Kaut kas ir noticis. Kaut kas ir noticis ar lazdām. Tu piesit, un lazdas nokūp zelta putekļos. Vai agrāk arī tā bija? Vai tu esi meties saules priekšā ceļos? Es, skaistais tatārs, to darīju Ai-Petrī virsotnē vējā un sniegā, un blakus bija saule manas skaistās tatārietes acīs. O, lielā saule, pateicies manam tēvam un manai mātei, kas man deva mīlošu sirdi! Pateicies viņas tēvam un mātei! Mums ir siltas rokas, mēs atmodinājām viens otru, mēs atsildījām viens otru, mēs kļuvām redzīgie.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2011\/2012"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Līdzās citām puķēm pašā dobes malā izdzina savu pirmo asniņu puķuzirnītis. Viņš ļoti priecājās par silto sauli, kas glāstīja zemi, tā atmodinādama tajā gulošos augus. – Cik skaista ir pasaule! – priecājās mazais puķuzirnītis. Viņš ar nepacietību sāka gaidīt to dienu, kad izaugs un varēs atraisīt pirmos ziedus. Bet nātre, paslēpusies dziļi zemē, smējās un draudēja: – Vai tu, tāds sīkais, domā izaugt garāks par mani un uzziedēt? Nekā nebūs! Nātre ātri sazēla un ar savu biezo ceru aizēnoja puķuzirnīša maigās lapiņas. Drīz vien puķuzirnītis sauli nemaz vairs nespēja saskatīt. – Redzi nu! – smējās ļaunā nātre. – Tā tu iznīksi, un neviens pat neuzzinās, ka tu esi bijis pasaulē! – Cik briesmīgi! – nobijās puķuzirnītis. Te līdzās puķuzirnītim ierunājās kāda klusa, laipna balss: – Nebēdājies, puķuzirnīt! Gan tu vēl uzziedēsi. Tikai atbalsties pret mani! Es tev palīdzēšu!",
+  "KLASE": 3,
+  "MACIBU_GADS": "2012\/2013"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Runātāja bija saulespuķe. Arī viņa vēl nebija izaugusi, tomēr tās lapas jau bija lielas un platas un kāts stingri turējās zemē. Puķuzirnītis paklausīja un apvija savas tievās rociņas ap stalto saulespuķes stāvu. Ar katru dienu saulespuķe auga augumā, bet kopā ar viņu stiepās arī puķuzirnītis. Tad kādu dienu saulespuķe uzziedēja. Zieds bija tik liels un košs, ka puķuzirnītis to noturēja par pašu sauli. – Cik tu esi skaista! – priecājās puķuzirnītis. –Arī tu esi skaists, – sirsnīgi sacīja saulespuķe. Tiešām – arī puķuzirnītis bija sācis ziedēt. Kā mazi zīda taureņi viņa zariņos sārtojās ziedi. Un cik tie saldi smaržoja! No malu malām salaidās bites un taureņi. Viņi visi priecājās par saulespuķes krāšņumu un apbrīnoja arī mazo puķuzirnīti. Viņš tagad droši bija pacēlies pretī saulei un sakuplojis košos ziedos. Bet nātre vai slāpa nost aiz dusmām, ložņādama turpat pie puķuzirnīša kājām. Tomēr viņa vairs nespēja nodarīt tam nekā ļauna. – Cik jauki dzīvot pasaulē, ja tev blakus ir labs un uzticams draugs! – priecājās gan bites, gan taureņi, gan puķes.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2012\/2013"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Puķuzirņi ir ātri augoši, ilgi ziedoši, viengadīgi vīteņaugi. Tiem ir ļoti krāšņi, daudzkrāsaini un ļoti smaržīgi ziedi. Puķuzirņu dzimtene ir Vidusjūras piekraste un salas. Pirmo reizi tie aprakstīti 1695. gadā, kad franciskāņu mūks Francisko Kupani tos iekļāva Sicīlijas salas savvaļas augu sarakstā. 1699. gadā F. Kupani puķuzirņu sēklas nosūtīja uz Angliju, un, sākot ar 1700. gadu, tos sāka audzēt Anglijā, vēlāk tie izplatījās arī uz citām zemēm, un joprojām ir populāri daudzviet pasaulē. Pirmie savvaļas puķuzirņi bija divkrāsaini – purpurkrāsa kopā ar tumši zilo. Tikai pēc 24 gadiem dārzniekiem izdevās izaudzēt baltus, tad pēc dažiem gadiem – sarkanbaltus ziedus. 19. gadsimta beigās jau bija radīti 7 atšķirīgu krāsu puķuzirņi. Jaunas šķirnes tika veidotas, krustojot jau esošās, un puķuzirņu svētkos Londonā bija izstādītas 264 to šķirnes. Par godu šim notikumam tika nodibināta Nacionālā puķuzirnīšu audzētāju biedrība. Puķkopji turpina veidot aizvien jaunas šķirnes – ar vairākiem ziedu ķekariem, viļņotām maliņām, maziem un lieliem ziediem. Mūsdienās ir sastopamas vairāk nekā 1000 puķuzirņu šķirnes, tos audzē gandrīz visās pasaules valstīs.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2012\/2013"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Automašīnai piebraucot, pats Mežaks stāvēja viesnīcas durvīs. Viņš bija mazliet uztraucies, bet, parādoties Mildiņai Cīrulītei, viņa bažas uzreiz izgaisa. Paņēmis meitenīti pie rokas, viņš to ieveda namā. Pa to laiku arī Vilis bija ienācis viesnīcas priekštelpās. – Nāciet, bērni! – Mežaks aicināja. – Es jūs aizvedīšu pie mazā mākslinieka, kura vārds ir Raimonds. Viņš ir drusku noguris no pastāvīgās braukāšanas pa koncertiem, bet, kad jūs ar viņu padzīvosieties, tas atkal atžirgs. Par koncertu un mūziku ar to nerunājiet, tā viņam līdz kaklam, viņš grib tikai rotaļāties. Viņš ir uz mata tāds pats kā citi bērni. Uzkāpuši otrajā stāvā, viņi pieklaudzināja pie mākslinieku durvīm, bet neviens neatsaucās. Trīs gaidītāji dzirdēja tik kādu sievieti rājamies: – Raimond, kas tad tā dara! Vai tas ir redzēts: viņš zīmē uz loga rūtīm!",
+  "KLASE": 6,
+  "MACIBU_GADS": "2012\/2013"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "– Nu ko tad lai es citu daru? – atbildēja raudulīga bērna balss. Vilim nāca smiekli: – Tam nu gan ir garš laiks! Es labāk metīšos tūliņ kūleniski pa durvīm iekšā! – Mežaks tikām bija klaudzinājis otrreiz. – Lūdzu! – atskanēja no iekšpuses tā pati sievietes balss. Plaši jo plaši atvērās durvis, un pa tām ienāca Vilis – uz rokām, kājas augšā, galva lejā! Kādu gabaliņu tā nostaigājis, viņš pārmeta trīsreiz kūleni – uz mīkstās grīdsegas tas nemaz nebija grūti – un tad tik vēl sniedza roku mazajam zēnam, kas iesmējās pilnā balsī, kā jau Vilis to bija paredzējis. Jaunkundze atviegloti uzelpoja: viņai novēlās kā slogs no pleciem. Tad viņa laipni pavērās Mildiņā. Mazā meitene, sajuzdama, ka viņas brālis bija uzvedies ne gluži tā, kā pienākas, draudzīgi paskaidroja: – Parasti Vilis ienākdams kūleņus nemet, šodien viņš to darīja mazā puisīša dēļ! Raimonds ar svešajiem bērniem bija sapazinies un sadraudzējies. Skaista bija viņa gaiš­ matainā, cirtainā galviņa, skaisti bija šaurās sejiņas smalkie vaibsti, bet vēl skaistākas bija lielās, zilās acis, kuru dzelmīgais skats liecināja, ka šis bērns jūt vairāk un dziļāk par citiem. Rotaļājoties viņš izskatījās tikpat bērnišķīgi priecīgs kā Mildiņa, bet, tiklīdz tas apklusa, viņa sejā izteicās neparasta nopietnība, to padarīdama daudz vecāku.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2012\/2013"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Sākumā Raimonds, skaļi smiedamies par Viļa jokiem, nodevās tikai tiem, kamēr Mildiņa klusēdama vēroja abus zēnus. Bet tad viņš piepeši pievērsās mazajai meitenei: – Ar tevi es gribētu dejot, vai tu proti dejot? – Jā, – sacīja Mildiņa. – Kādu deju mēs dejosim? – Kāda tev pašam patīk, – atbildēja mazā, brālim par lielum lielo brīnumu. Viņam tā bija pirmā dzirdēšana, ka māsiņa prot dejot. – Dejosim valsi! – nolēma Raimonds, satverdams Mildiņu aiz rokas. – Pagaidi drusku, Vilis man to parādīs! Vilis savu mūžu vēl nebija dejojis, bet tā viņam bija maza bēda. – Valsim jāskaita trīs, – viņš pamācīja māsiņu. – Es uzsvilpošu kādu meldiņu. Svilpodams, rokām sitot rakstā, viņš sāka griezties. Jaunkundze, paslēpusi seju aiz grāmatas, vai mira aiz smiekliem. Raimonds ātri apskāva Mildiņu. Tā kā Mildiņas dzīslās ritēja mūzikas skolotāja asinis, nebija ko brīnīties, ka viņa uz vietas uztvēra ritmu. Cieši saķērušies, abi mazie dejoja pa istabu, kuras vienā kaktā svilpodams, pastarpām arī čāpstinādams un ņurdēdams, cilājās un grozījās Vilis. Bērniem nemanot un nezinot, jaunkundze pasauca Rožkalnus. Raimonda māte, arī viņa tēvs parādījās durvīs. – Ja mēs šo numuru pievienotu šā vakara koncerta programmai, ļaudis smietos pilnā kaklā! – jokoja mākslinieks.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2012\/2013"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Raimonds iecirtās, paziņodams, ka viņš neēdīšot, nepārģērbšoties un savus jaunos draugus\nprojām nelaidīšot. Nelīdzēja nedz audzinātājas nopietnie vārdi, nedz mātes mīļie glāsti. Visbeidzot\nviņš sāka pat raudāt.\nArī Vilis mēģināja mazo zēnu pierunāt. – Tev taču šovakar jāspēlē koncertā, – viņš aizrādīja, –\niedomājies, cik daudz cilvēku priecāsies par tavu uzstāšanos! – Vai jūs arī iesit? – vaicāja mazais\nRaimonds.\nBet šoreiz Vilis viņam pa prātam nevarēja izdarīt. – Mēs nevaram nākt, – viņš sacīja, – Mildiņa ap to laiku jau guļ, un man ir jāmācās. Uz rītdienu ir daudz uzdots, un nu jau es tikpat\nesmu pazaudējis visu pēcpusdienu viesnīcā. – Raimonds, piespiedis galviņu pie mātes krūtīm,\nšņukstēja: – Ja Vilis nenāks, es nespēlēšu! Man nav labi, man nav labi! – Viņš tiešām izskatījās\nnožēlojams.\nDziedātāja pasauca savu vīru. – Paskaties, kāds Raimonds ir nolaidies un noraudājies! – viņa\nbēdājās. – Kas viņam kait? Citādi viņš taču ir prātīgs zēns, bet šodien negrib un negrib spēlēt!\nKas tās man būs par mokām šovakar! Tēva sejā izpaudās nepacietība. Raimonds cieši ieķērās\nViļa rokā, negribēdams to nemaz vairs vaļā laist. Zēna vecāki uzsāka dzīvu sarunu, no kuras\nbērni nekā nesaprata: tā notika itāļu valodā.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2012\/2013"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Rožkalns pievērsās Vilim:\n– Mēs tev būtu ļoti pateicīgi, ja tu šovakar atnāktu uz koncertu. Mēs arī labprāt atlīdzinātu šo\nnācienu: es tev iedošu brīvbiļeti.\nDzirdot vārdu „brīvbiļete”, Vilim karsts vien izskrēja caur miesu. – Jā, jā, jā! – viņš iesaucās\ngaviļu balsī. – Par brīvbiļeti, ja es to varu dot savam tēvam, es palikšu pie Raimonda, cik ilgi\ntik jūs gribēsit! Es mācīšos manis pēc līdz gaiļiem! – Un, pamanījis, ka puisēna asarotajās\nacīs iemirdzas mazs smiekliņš, viņš ņēmās to vēl vairāk smīdināt. – Kaut tu varētu noskatīties,\nRaimond, kā priecāsies mans tēvs, saņemdams šo brīvbiļeti! Viņš ir garš kā baznīcas tornis, un,\nja aiz prieka palecas uz augšu, tad tur ir, ko redzēt! – Un Vilis sāka rādīt, kādiem lēcieniem, biļeti\nsaņēmis, lēkšos viņa tēvs, tā ka mazais zēns skaļi iegavilējās.\n– Bērnam jāpārģērbjas, kamēr viņš vēl priecīgs, – čukstēja dziedātāja, un Raimondam viņa sacīja:\n– Ja tu būsi rātns, Vilis šovakar atnāks pie tevis. Raimonds paklausīja uz pēdām, un viņa tēvs\nteica Vilim: – Koncerts ir mūzikas skolā.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2012\/2013"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Es zinu, tur bieži esmu bijis. Mans tēvs ir skolotājs mūzikas skolā, – atteica Vilis.\n– Mūzikas skolotājs? Un nav iegādājies biļeti uz mūsu koncertu?\n– Nē, bet nezinu citu cilvēku pasaulē, kurš tik labprāt gribētu iet uz šo koncertu!\nAbiem bērniem tā dega pēc mājām, ka rokas trīcēja vienā trīcēšanā. Saņemot biļeti, Vilim bija\ncieši jāapsolās noliktajā laikā ierasties mūzikas skolā.\nPakampis māsiņu aiz rokas, viņš to drīzināja: – Veicīgi, veicīgi, Mildiņ! Kaut tik nu tēvs nebūtu\nvien izgājis, pulkstenis jau ir seši, un pusastoņos sākas koncerts!\nPa galvu pa kaklu abi bērni noskrēja pa kāpnēm cauri priekšnamam laukā uz ielas.\nVilim būtu daudz labāk paticis ņemt kājas pār pleciem, lai tādējādi izskrietu savu lielo prieku,\nbet māsai braukšana bija ļoti pa prātam.\nKad pie mājas piestāja autiņš, Cīrulītis izskrēja uz ielas un rāva vaļā automašīnas durtiņas,lai\npajautātu, kur bērni tik ilgi kavējušies. Tomēr viņš nepaguva bilst ne vārda, jo bērni viens caur\notru sauca: – Cik labi, tēt, ka esi mājās! Mēs tev atnesām koncertbiļeti, mākslinieks pats mums\nto uzdāvāja!",
+  "KLASE": 6,
+  "MACIBU_GADS": "2012\/2013"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Latvijas Republikas 1991. gada 19. marta likumā „Par Latvijas nacionālo un etnisko grupu\nbrīvu attīstību un tiesībām uz kultūras autonomiju” pirmoreiz tika noteikts lībiešu juridiskais\nstatuss – „sena Latvijas pamattautība”. 1999. gada 9. decembrī pieņemtā Valsts valodas likuma\n4. pantā teikts, ka valsts nodrošina lībiešu valodas kā pirmiedzīvotāju valodas saglabāšanu,\naizsardzību un attīstību. No 1995. gada atbilstoši Latvijas kultūrpolitikas pamatnostādnēm lībiešu\nvaloda un kultūras vērtības ir iekļautas Latvijas nacionālā kultūras mantojuma sastāvā.\nAr lībiešiem Latvijā vēsturiski ir saistāmas vietas gan Kurzemē, gan Vidzemē. Nozīmīgākā\napdzīvotā vieta ir Rīga, kur jau pilsētas dibināšanas laikā atradās lībiešu apmetnes. Ar lībiešiem\nsaistāmas tādas pilsētas un apdzīvotas vietas kā Ainaži, Aizkraukle, Cēsis, Ikšķile, Kandava,\nLimbaži, Mazsalaca, Salacgrīva, Salaspils, Talsi, Turaida, Ventspils u. c.\nAtšķirībā no indoeiropiešu valodu saimē ietilpstošās latviešu valodas lībiešu valoda pieder\npie somugru valodu saimes Baltijas jūras somu valodu atzara. Līdztekus lībiešu valodai Baltijas\njūras somu valodu grupā ietilpst arī igauņu, somu, karēļu, vepsu, ižoru un votu valoda. Tālākās\nlībiešu radu valodas ir sāmu jeb lapu valoda, mordviešu, mariešu valoda, Permas somu valodas\n(komiešu un udmurtu) un ugru valodas (ungāru valoda un divas Obas ugru grupas valodas: hantu\nun mansu).",
+  "KLASE": 9,
+  "MACIBU_GADS": "2012\/2013"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Lībiešu rakstu valoda sāka attīstīties 19. gadsimta vidū, pateicoties somu un igauņu\nvalodniekiem.\nPamanāmākās lībiešu valodas atstātās pēdas latviešu valodā ir uzsvars uz pirmās\nzilbes, latviešu valodas lībiskās izloksnes Vidzemē un Kurzemē, kā arī daudzie ikdienā lietojamie\naizguvumi. Par lībiskas cilmes vietvārdiem uzskatāmi Ainaži, Ķirbiži, Korģene, Kuiviži, Kuiķule,\nLēdurga, Puikule, Umurga, Ādaži, Gauja, Ikšķile, Jugla, Kadaga, Lilaste, Lieluikas un Mazuikas\nezers, Piķurga, Ropaži, Suntaži, Suži, Ummis, Ģipka, Kolka, Matkule, Usma un Venta. Latviešu\nvalodā atrodami daudzi lībiešu valodas cilmes vārdi, piemēram, allaž, jauda, kāzas, kukainis, ķīla,\nlaulāt, loms, muiža, pīlādzis, puisis, puķe, selga, sēne, suga, sulainis, vai, vajag, vimba.\nLatvijā lībiešu valoda nekad nav bijusi skolas, baznīcas vai iestādes pastāvīgā darba\nvaloda. Tā ir lietota tikai ģimenē vai sadzīvē. No 1923. līdz 1939. gadam lībiešu valodu kā izvēles\nmācību priekšmetu varēja apgūt vairākās Ziemeļkurzemes jūrmalas skolās, to skaitā Mazirbē\nun Kolkā. Mūsdienās lībiešu valodu var apgūt kursos un pašmācības ceļā. Ar lībiešu valodu var\niepazīties augstākajās mācību iestādēs Latvijā, Igaunijā, Somijā un citās valstīs. Tā ir iekļauta\nUNESCO veidotajā apdraudēto valodu sarakstā.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2012\/2013"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Zinātnieki lēš, ka 2010. gadā pasaulē, tai skaitā arī Latvijā, kopumā varēja būt aptuveni 40 cilvēku, kuri spēja sazināties lībiešu valodā, bet lībiešu valodas pamatus apguvušo skaits bija ap diviem simtiem. No tiem lielāko daļu veidoja lībiešu valodas pētnieki un interesenti. 2011. gadā bija zināms tikai viens cilvēks (Kanādā dzīvojošā Grizelda Kristiņa), kam lībiešu valoda ir dzimtā (pirmā) valoda. Lībiešu mūziku var dzirdēt gan dzīvajā izpildījumā, gan ierakstos. Pirmais lībiešu koris tika izveidots 1922. gadā Sīkragā. Joprojām darbojas divi lībiešu dziesmu ansambļi, kas nodibināti 1972. gadā – „Līvlist” Rīgā un „Kāndla” Ventspilī. Lībiešu mūziku atskaņo arī folkloras kopa „Skandinieki”. Seni lībiešu tautasdziesmu motīvi dzirdami Raimonda Tigula mūzikas albumā „Zaļš, balts, zils” (2005). Igaunijā izdots lībiešu tautas mūzikas albums ar ierakstiem, kas tapuši laikā starp abiem pasaules kariem, kā arī 20. gadsimta 80. gados.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2012\/2013"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Lībiešu folklorā visbiežāk sastopamās būtnes ir mātes un tēvi – Ziemas tēvs, Vēja tēvs, Sala tēvs, Vētras māte, Jūras māte, Purva māte un citi. Jūrā mīt gan Jūras mātes zilās govis, gan arī zilie jūras zirgi. Lībiešu folklorā aprakstītās un lībiešu ciemos izplatītās zilās govis daudzviet Latvijā dēvē arī par „lībiešu govīm”. Lībiešu tautas kalendārā nozīmīga vieta bija Lieldienām, kuru rituāli pārsvarā saistīti ar jūru un zvejniecību. Piemēram, pirmo Lieldienu rītā deva ziedojumu Jūras mātei, lai iegūtu jūras labvēlību. Tad arī notika tā sauktais putnu modināšanas rituāls. Vēl lībiešiem bija svarīgi vasaras un ziemas saulgrieži. Interesantas ieražas saistās ar Meteņiem un Pelnu dienu. Visā Latvijā populāra kļuvusi lībiešu tautasdziesma „Pūt, vējiņi!”.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2012\/2013"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Monogrāfijas autors Valts Ernštreits stāsta: „Ar lībiešu rakstu valodas kopšanu esmu nodarbojies nu jau vairāk nekā piecpadsmit gadu. Šī grāmata, tāpat kā pagājušā gada nogalē Tartu Universitātē aizstāvētā doktora disertācija, uz kuras pamata tā tapusi, ir mans veltījums trijām Vaides ciema lībietēm, kas šajā laikā ir bijušas manas atbalstītājas, sarunu biedrenes, iedvesmotājas, skolotājas un ceļvedes gaistošajā lībiešu pasaulē: otrpus Atlantijas okeānam dzīvojošajai Grizeldai Kristiņai, Vaides kapos apglabātajai Elzai Mansūrovai un visvairāk – Paulīnei Kļaviņai, kas atdusas tepat Rīgā, Meža kapos. Vienlaikus šī grāmata ir cieņas apliecinājums tiem, kuri lībiešu valodas kopšanas laukā strādājuši pirms manis un kuriem varu būt pateicīgs par to, ka lībiešu valoda ir un paliks tāda, kādu es to pazīstu – mūsdienīga, bagāta un skaista.”",
+  "KLASE": 9,
+  "MACIBU_GADS": "2012\/2013"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Dr. habil. philol. Ina Druviete, vērtējot monogrāfiju, atzīst: „Valta Ernštreita grāmata ir īpaša. Tā ļauj mums izdzīvot veselas tautas dzīvesstāstu. Grāmata ir nopietns zinātnisks pētījums, tomēr to varam lasīt kā aizraujošu ceļojuma aprakstu lībiešu tautas un valodas vēsturē, etnogrāfijā, dzīvesziņā. Atmiņu stāsti tajā savīti ar dokumentālām liecībām. Pētījums pārliecinoši parāda, cik liela nozīme tautas ilgtspējā ir vienotai literārajai valodai, kas, Kārļa Mīlenbaha vārdiem runājot, kā vainags vīts no krāšņākajām izlokšņu puķēm, stiprina etnosa vienotības apziņu. Grāmata ir spēcīgi intelektuāla, gan lībisko, gan latvisko, gan globālo vēju caurstrāvota – kā saka pats autors Valts Ernštreits. Grāmata ir par lībiešiem, bet tā noderīga it īpaši latviešiem. Tā nav tikai piemineklis aizgājušiem laikiem, un tā nav tikai stāsts par vienas tautas un valodas likteni. Tā ir mācībgrāmata mums visiem, cik trausla ir tautas dzīvība, kā tā jāuztur un jāsargā.”",
+  "KLASE": 9,
+  "MACIBU_GADS": "2012\/2013"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Grāmatas ievadā autore raksta: „Kad bijām iekārtojušās Kolkā (Baiba ar mammu Valdu Mariju Šuvcāni atgriezās dzimtajā krastā 2006. gadā), radās jautājums, ko tad mēs te darīsim. Bijām jau uzrakstījušas un apgāds „Jumava” izdevis trīs grāmatas par lībiešiem – „Lībiešu ciems, kura vairs nav” (2002), „Lībiešu folklora” (2003), „Mazirbe – mazs ciems jūrmalā” (2006).” Šajā grāmatā Baiba Šuvcāne apkopojusi un atspoguļojusi Kolkas ciema kultūrvēsturi vairāku gadsimtu garumā – no 1040. gada, kad Kolka pirmo reizi minēta vēstures avotos, līdz pat mūsdienām. Akcentēta tradicionālās kultūras – dzīvesveida, izglītības, tradīciju, muzikālās kultūras, reliģiskās piederības, folkloras – nozīme ciema vēsturē un attīstībā. Darbā plaši atspoguļota lībiešu dzimtu attīstība un pēctecība Kolkas ciemā. Grāmatas veidošanā izmantoti arhīvu, bibliotēku materiāli, Kolkas ciema iedzīvotāju un personīgās atmiņas, materiāli lībiešu valodā, kas savākti vairāk nekā 20 iepriekšējos darba gados. Šie materiāli papildināti ar pēdējo gadu vākumu – 60 Kolkas iedzīvotāju atmiņu stāstījumiem.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2012\/2013"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Igaunijas Dzimtās valodas biedrība un Lībiešu kultūras centrs izdevis Kārļa Staltes grāmatu „Jelzi sõnā. Ābēd ja īrgandõks lugdõbrōntõz” („Dzīvais vārds. Ābece un sākuma lasāmgrāmata”). Tā ir pirmā ābece, kas jebkad uzrakstīta lībiešu bērniem, un šo lībiešu kultūrvēsturē nozīmīgo darbu jau 1938. gadā pabeidzis lībiešu dzejnieks, kultūras un sabiedriskais darbinieks Kārlis Stalte pēc Dzimtās valodas biedrības pasūtījuma. Taču tikai 2005. gada vasarā Igaunijas Valsts arhīvā Tallinā, pētot Igaunijas Dzimtās valodas biedrības dokumentus, lībiešu ābeces manuskriptu pavisam nejauši uzgāja vēsturniece Renāte Blumberga.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2012\/2013"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Grāmatas manuskriptā bija atstāta vieta ilustrācijām, bet pašu ilustrāciju nebija. Tā kā ābeces izdevums ir tapis, sadarbojoties divu valstu – Igaunijas un Latvijas – organizācijām, Lībiešu kultūras centrs vēlējās, lai par ābeces ilustrāciju autoriem kļūtu abu valstu skolēni. Lībiešu valodas un kultūras gada sākumā tika izsludināts zīmējumu konkurss divās Latvijas skolās – Vidzemes lībiešu agrāk apdzīvotās teritorijas Pāles pamatskolā un Kurzemes lībiešu ciema Kolkas pamatskolā – un divās Igaunijas skolās – Metsapoles un Kilingi-Nemmes. Abas atrodas Vidzemes pierobežā, un, visticamāk, arī šajās vietās kādreiz tika runāta lībiešu valoda. Atsaucība bija milzīga, tādēļ nebija viegli izvēlēties labākos. Tā nu grāmatas māksliniece Zane Ernštreite nolēma, ka katrs konkursa dalībnieks ir pelnījis piedalīties šajā vēsturiskajā notikumā un lībiešu ābecē publicējami pilnīgi visi iesniegtie darbi. „Dzīvais vārds” ir ne tikai pirmā lībiešu valodas ābece, bet arī jauns un autentisks lībiešu tekstu krājums, kas vienkāršās valodas dēļ ir izcili piemērots mācību vajadzībām.Turklāt „Ābece un sākuma lasāmgrāmata” sniedz interesantas ziņas un vērojumus par lībiešu dzīvi Ziemeļkurzemes zvejnieku ciemos, par lībiešu attiecībām ar kaimiņu tautām, par dabu un tradīcijām.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2012\/2013"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Lietpratīgam, radošam daiļliteratūras lasītājam piemīt literārā kompetence. Lai tā izveidotos,\nskolēnam ir jāapgūst precīza, lēna, rūpīga literārā darba lasīšana, ko pareizāk būtu nosaukt par literārā\ndarba studēšanu. Skolēns, ieguldot daudz laika un pacietības, iedziļinās katrā darba teikumā, rindkopā,\nlappusē. Tas nozīmē, ka skolēns vienu un to pašu tekstu lasa atkārtoti. Tā ir pētnieciskā lasīšana, kad\nlasītājs nopietni un atbildīgi izturas pret literāro darbu un velta tam laiku un uzmanību.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2012\/2013"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "21. gadsimtā mainās daiļliteratūras lasīšanas tradīcijas sabiedrībā, un šīs pārmaiņas raksturo\ngan lasīšanai atvēlētais laiks, gan lasīšanas motīvi, gan attieksme pret grāmatu lasīšanu, gan prasme\norientēties plašajā grāmatu klāstā. Diemžēl viskrasākās pārmaiņas attieksmē pret daiļliteratūras lasīšanu\nvērojamas tieši pusaudžu un jauniešu vidū, un šīs tendences liek domāt, ka interese par lasīšanu un\nizpratne par grāmatu kā vērtību zūd.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2012\/2013"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Literatūrai ir nenovērtējama loma personības tapšanas procesā, grāmata var būt ceļvedis zināšanu\nun jūtu okeānos, cilvēcisko attiecību un emociju džungļos, vērtību kalnājos un piedzīvojumu kanjonos.\nTieši lasīšana var būt tā, kas nosaka cilvēka attieksmi pret pasauli visam viņa mūžam un virza viņu uz to,\nko saprotam ar īstu cilvēciskumu. Tikai kvalitatīvu grāmatu daudzveidība var nodrošināt iespēju katram\nlasītājam rast savai gaumei, interesēm un vajadzībām atbilstošu lasāmvielu.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2012\/2013"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Neviens vairs nelasa grāmatas. Tās nevienam vairs nav vajadzīgas. Uz bibliotēkām iet tikai studenti\npirms eksāmeniem un pensionāri – pašķirstīt presi debesu valstības uzgaidāmajā telpā. Grāmatu veikalos\niegriežas tikai dīvaiņi, un arī tie aiziet tukšām rokām, ja vien grāmatas netiek mestas pakaļ par santīmiem.\nVisi pārējie sēž internetā, lasa ziņu portālus, aplūko ēdienu gatavošanas blogus, pārsūta viens otram\nsmieklīgus YouTube videoklipus, regulāri iegriežas sadzīviska rakstura vietnēs vai sāk dienu, ierakstot\ninternetā download mp3.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2012\/2013"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Kaut arī digitalizācija palīdz saglabāt neskaitāmas grāmatas, kuras citādi būtu lemtas bojāejai un aizmirstībai, digitālais teksts dažādu iemeslu dēļ ir pārāk zūdošs un nepastāvīgs, lai mēs varētu uz to paļauties. Vai elektronisko grāmatu nestabilitāte un neuzticamība kļūs par drukāto grāmatu glābšanas riņķi? Baidos, ka nē. Drīzāk mēs klusi nolemsim, ka kultūras mantojuma saglabāšana nav svarīgākais šajā dzīvē, un to pat ir grūti apstrīdēt, ja grāmatas (ko neviens nelasa) pretnostata daudz ātrākām un saprotamākām baudām. Drukātās grāmatas varbūt interesēs tikai šauru cilvēku loku, un tās būs pieejamas tikai muzejos.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2012\/2013"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Iespējams, tās ir ļoti pesimistiskas prognozes, taču tās ir reālistiskas. Jo problēma ir nevis medijā,\nbet gan cilvēku paradumu izmaiņās. Mēs negribam lasīt, mēs gribam pārlūkot. Un elektroniskās grāmatas\nsavā vieglumā, neobligātumā un ātrumā to piedāvā daudz lielākā mērā nekā kilogramīgs „Annas Kareņinas”\nsējums. Lasot to pašu „Annu Kareņinu” elektroniskajā lasītājā, es varu bez sirdsapziņas pārmetumiem\npievērsties Tolstoja biogrāfijai, tad nogurt un pašķirstīt kādu žurnālu, un to visu darīt, piemēram, braucot\nvilcienā. Un vaina nav tajā, ka drukātā grāmata ir tik smaga, bet tajā, ka es nemaz negribu lasīt visu „Annu\nKareņinu”, un te nepalīdzēs ne augstais attēla kontrasts, ne grāmatas ilgais mūžs, ne iespēja zīmēt uz\nlappušu malām ķiņķēziņus.\nTomēr es ceru, ka drukātās grāmatas tuvākajos gados un varbūt pat gadu simteņos nekļūs par\nsavādu vēstures liecību. Es ticu, ka mēs spējam pretoties kārdinājumam apkošļāt informācijas driskas un\natradīsim sevī tādu dvēseles daļu, kas grib domāt un iedziļināties.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2012\/2013"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Biezā mežā dzīvoja divas vāverītes. Viena vāverīte visu dienu strādāja, bet otra bezrūpīgi tupēja koka zarā, lēkāja un svilpoja tā, ka viss sils skanēja. Sagribas ēst – maza bēda, vasarā visur ēdamā pietiekami. Tā slinkā vāverīte aizvadīja visu vasaru. Tikmēr čaklā un gādīgā vāverīte bija sev sagādājusi ziemai visādu ēdamo, – čiekurus, riekstus un bekas. Pat mājiņu izklājusi ar sūnām. Pienāca saltā ziema – ne sēņu vairs, ne riekstu, tikai vējš dzenā sniegu. Čaklā vāverīte dzīvoja savā dobumā un bēdu nepazina",
+  "KLASE": 3,
+  "MACIBU_GADS": "2013\/2014"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Bet vieglprātīgajai biedrenei klājās pavisam grūti – pa māju svilpodams skraidīja auksts vējš. Vāverīte atcerējās čaklo un strādīgo kaimiņieni un devās lūgt palīdzību. Čaklā vāverīte atvēra durvis, ieraudzīja nelaimīgo kaimiņieni un tūdaļ visu saprata. „Lūdzu, apsēdies! Pagādāšu tev riekstus un zīles. Ēd nu vesela un dzīvo pie manis!” Slinkā vāverīte nopriecājās un pateicās kaimiņienei. Slinko vāverīti trūkums bija iemācījis strādāt. Nākamajā vasarā viņa čakli palīdzēja kaimiņienei. Turpmāk abas dzīvoja laimīgi un pārticīgi.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2013\/2014"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Lācēns Vinnijs Pūks gāja pie sava drauga Kristofera Robina, kas dzīvoja otrā\nmeža malā.\n– Labrīt, Kristofer Robin, – viņš teica.\n– Labrīt, Vinnij Pūk, – Kristofers Robins atbildēja.\n– Vai tev ir kāds balons?\n– Balons? Kam tev vajadzīgs balons? – Kristofers Robins jautāja.\n Vinnijs Pūks paskatījās apkārt, vai neviens nenoklausās. Pielika ķepu pie\nmutes un aizžņaugtā balsī nočukstēja: „Medus!”\n– Vai tad kāds iet pēc me",
+  "KLASE": 3,
+  "MACIBU_GADS": "2013\/2014"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "– Es eju, – sacīja Pūks. Labi, ka dienu iepriekš Kristofers Robins bija viesībās pie sava drauga Sivēna, un Sivēns katram ciemiņam uzdāvināja balonu. Kristoferam Robinam tika viens liels zaļš balons un viens liels zils balons. Kristofers Robins pārnāca mājās ar abiem baloniem – zilo un zaļo. – Kurš tev patīk labāk? – Kristofers Robins jautāja Pūkam. Viņš saņēma galvu ķepās un ilgi domāja. – Kas ir galvenais, ejot pēc medus ar balonu? – viņš prātoja, – galvenais ir, lai bites nepamana.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2013\/2014"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Ja man būs zaļš balons, tas izskatīsies pēc lapām, un viņas neko nenojautīs. Ja man būs zils balons, tas izskatīsies pēc debesīm, un viņas atkal nenojautīs. Vajag tikai izvēlēties, kā labāk. – Bet vai bites neredzēs, ka zem balona esi tu? – Varbūt redzēs, bet varbūt arī neredzēs, – teica Vinnijs Pūks. – Ar bitēm nekad neko nevar zināt. – Viņš brīdi padomāja un piebilda: – Es izlikšos par mazu, melnu mākonīti un piemānīšu bites. – Tad labāk ņem zilo balonu, – teica Kristofers Robins. Tā arī izdarīja. Pūks paņēma zilo balonu, un abi ar Kristoferu Robinu devās ceļā. Viņu mērķis bija lielais ozols.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2013\/2014"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Aleksam un Bastijam ir māsīca, kas kā uzburta uz brīvprātīgo darbu. Tas ir tāds darbs, kur tu strādā,\nbet par to nemaksā. Brīvprātīgais darbs šķiet viena vienīga izklaide, par ko beigās visi tevi ļoti slavē un ir\nar mieru ja ne nopirkt riteni, tad vismaz izmaksāt kasti lielo saldējumu.\nLai sāktu strādāt par brīvprātīgo, vajag tik palūkoties apkārt, kāds uzlabojums nepieciešams, un\nķerties pie darba.\nNākamajā rītā izgājām ārā palūkoties uz mūsu mājas pagalmu un novērtēt, kas tur būtu uzlabojams.\n– Vai karuseļi dārza stūrī neizskatītos brīnišķīgi? – jautāja Bastijs.\n– Varbūt karuseļi tajā stūrī, bet šajā – neliels akvaparks? – man arī bija ideja.\n– Kāpēc starp mājām nevarētu ierīkot motokrosa trasi un katram, kas tuvojas šim rajonam, izsniegt\nmotociklu braukšanai? – sarunā iesaistījās arī Alekss.\n– Katram? Kā tu iedomājies savu vecmāmiņu uz motocikla? – smējās Anete.\n– Varbūt vecmāmiņas varētu braukt ar kvadraciklu? – mazliet padomājis, jautāja Alekss.\n– Varbūt sāksim ar kaut ko reālu?",
+  "KLASE": 6,
+  "MACIBU_GADS": "2013\/2014"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Tāda ir Anete. It kā vecmāmiņa uz kvadracikla būtu kaut kas nereāls! – Kristap, kā būtu, ja mēs nokrāsotu soliņus? – Alekss ierosināja. – Tas būtu sabiedrībai derīgs darbs. – Vai tu uz soliņiem bieži sēdi? – es nenocietos nepavaicājis. – Nē, bet tur sēž mūsu vecmāmiņa. Lai nu tā būtu! Var izrādīties, ka soliņu krāsošana ir patīkams darbs. Janka apsolīja dabūt grīdas krāsu. Alekss sagādās krāsojamo rullīti, bet Anete devās pēc otām (uz pagrabu vai veikalu – ja nebūs vienā, būs otrā). Man jāsameklē smilšpapīrs, savukārt Bastijam tika uzticēts no tēva darbarīku kastes paņemt špakteles. Man un Bastijam vajadzēja arī kasīt no soliņa veco krāsu. Varētu domāt, ka tas ir tik viegli! Mēs nopūlējāmies vismaz pusstundu, un Bastijs beidzot teica, ka labāka ideja būtu bijusi uztaisīt jaunu soliņu. Man savukārt likās, ka soliņš te vispār nav vajadzīgs. Var taču sēdēt zālē, vai ne? Vai smiltīs – nu, vienalga.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2013\/2014"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Un kā jūs domājat, vai tad, kad pārpūlējušies apsēdāmies zemē pie tīrinoskrāpētā soliņa (darbmācības skolotājs neteiktu, ka tas ir tīrs, bet mums pašiem tā likās), mums bija brīdis atpūsties? Nekā! Tūlīt bija klāt arī Janka ar krāsu. Kur viens cilvēks var veselu pusstundu meklēt krāsas bundžu? Šo jautājumu uzdevu Jankam, un viņš paziņoja, ka esot to meklējis mājās, pieliekamajā, pagrabā, siltumnīcā un beidzot atradis garāžā. Brīnums, ka viņš nebija meklējis ledusskapī. Tūlīt ieradās arī Anete un Alekss ar darbarīkiem, un mēs ķērāmies vērsim pie ragiem. Soliņam bija pieci dēļi, tāpēc izlēmām katrs krāsot savu dēli. Tas negāja tik gludi, kā iecerēts, jo dažs krāsoja ātrāk, cits – lēnāk, turklāt visi mērca otu vienā krāsas bundžā un laiku pa laikam pilināja krāsu citiem uz rokām.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2013\/2014"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Pēc krietniem pūliņiem, notašķītām rokām un nedaudz nosmērēta\nasfalta visapkārt soliņš bija nokrāsots. Arī rokas mums visiem bija nokrāsotas. Mēs devāmies tās\nnotīrīt.\nKļūda! Izrādās, ka svaigi padarītu darbu nedrīkst atstāt nepieskatītu. Kad mēs tīrām rokām nācām\natpakaļ palūkoties uz savu darbu, soliņam bīstamā ātrumā tuvojās divas kaimiņmāju vecmāmiņas ar\nmazbērniem.\n– Tur nedrīkst sēdēt! Tas ir mūsu soliņš! – es iesaucos.\nAnete apgalvo, ka tas esot bijis nepieklājīgi. Pareizais sauciens būtu bijis „Krāsots!” Vecmāmiņas,\nnoturējušas mūs par nekaunīgu tīņu bariņu, nikni nošņācās un apsēdās uz svaigi krāsotā soliņa. Gods\nkam gods, to, ka soliņš ir krāsots, viņas pamanīja, bet bija jau par vēlu. Tagad mūsu darbu rotāja divi\nskaisti nospiedumi…",
+  "KLASE": 6,
+  "MACIBU_GADS": "2013\/2014"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Pēc pusdienām satikāmies pagalmā pie dārziem pārrunāt dienas plānus. Alekss uzskatīja, ka mums\njāpārdomā brīvprātīgo darbs, citādi visi labie nodomi būšot vējā. Tā viņš teica tāpēc, ka dažas no mūsu\nbrīvprātīgā darba iecerēm ļoti nepatika citiem iedzīvotājiem.\n– Galu galā jāpierāda citiem, ka mēs veicam darbu sabiedrības labā! Ja mums izdosies radīt kaut ko\nskaistu, citi priecāsies, – visus iedvesmot centās Alekss.\n– Aleks, – Bastijs sacīja. – Tu runā kā tētis.\n– Vismaz ne kā vecmāmiņa, – Alekss atcirta. – Paklausieties, kā būtu, ja mēs kaut ko apgleznotu?\n– Vai šalles? – Anetei radās doma.\n– Mājas sienu? – ieteica Janka.\n– Asfaltu? – arī es iesaistījos.\n– Nemuļķojies, Kristap! Apgleznosim akmeņus. Mākslas skolā mācīja, – Alekss izteica savu priekšlikumu.\n– Un tieši kurus akmeņus? – bijām ļoti ieinteresēti.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2013\/2014"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Mēs palūkojāmies apkārt. Akmeņu ienaidnieki bija aizvākuši no tuvākās apkaimes visus akmeņus,\njo neviens no šiem derīgajiem izrakteņiem nebija redzams.\n– Akmeņus mēs dabūtu no Sašonkuļa, – Janka ierosināja. Viņa apbūves gabals bija netālu no Jankas\ndārza. – Es redzēju, ka viņš sakrāvis veselu kaudzi sava būvlaukuma stūrī.\n– Vai domā, ka viņš gribētu, lai mēs viņa jaunbūvi izrotātu ar apgleznotiem akmeņiem?\n– Nē, – Alekss iejaucās. – Mēs akmeņus atvestu un noliktu kaut kur citur. Piemēram, apkārt autostāvvietas\nlaukumam. Tad ļaudis no rīta un vakarā varēs uz tiem lūkoties.\n– Paskaidrošu. Tā kā mēs dzīvojam rajonā, kas atrodas tuvu šosejai, tad mūsu autostāvvieta ir asfaltēts\nlaukums bez žoga. Akmeņi ap to tiešām uzlabotu izskatu. Turklāt apgleznoti akmeņi!\nLai tā būtu! Anete aizgāja pēc otām, Alekss – pēc krāsām, bet mēs trijatā devāmies pie Sašonkuļa.\nJanka stūma ķerru, Bastijam bija uzdevums ķerrā iekraut akmeņus, bet es runāšu ar Sašonkuli un lūgšu\nakmeņus.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2013\/2014"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Protams, turpceļā ķerru izmantojām daudz labākiem mērķiem un visi tajā pavizinājāmies. Kad katrs\nno mums vismaz reizi bija kļuvis par pasažieri, klāt bija apbūves gabals.\nLai nu kā man veicās sarunā, Sašonkulis akmeņus mums iedeva. Piekrāvām ķerru tik pilnu,\nka es un Janka tikko varējām pastumt (Bastijam ļāvām atpūsties, jo viņš bija noguris, kraujot\nakmeņus), un devāmies autostāvvietas laukuma virzienā.\nAnete un Alekss mūs jau gaidīja ar krāsām un otām.\nTurpmākais izrādījās ļoti vienkārši. Kārtīgi izstrīdējušies par to, vai akmeņus kārtot no lielākā\nlīdz mazākajam vai otrādi, novietojām tos vienā malā un ķērāmies pie gleznošanas. Vai zīmēšanas.\nKāds nu kuram bija talants.\nPamazām uz akmeņiem rindojās dinozauri, saules, jūras viļņi, futbolbumba, volejbola bumba (tas\nbija nošpikots!), puķes, koki, suņi, kaķi.\nGodīgi sakot, vizuālās mākslas skolotāja tos neatzītu par izciliem darbiem (ja nu vienīgi Aleksa\nveikumu), tomēr skolotājai nebija automašīnas, tāpēc viņa mūsu veikumu neredzēs.\nŠo darbiņu mums izdevās paveikt bez starpgadījumiem, tomēr vakarā…\nKad mēs bijām paēduši vēlas vakariņas, beidzot no semināra atgriezās tēvs. Viņš bija ļoti dusmīgs,\njo bija uzbraucis vienam gar stāvvietu novietotam akmenim un noskrāpējis mašīnu.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2013\/2014"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Pirms 300 gadiem īstais Robinsons Krūzo tika izglābts no salas ieslodzījuma, kurā viņš nebūt\nnebija nelaimīgs. Pētniekiem izdevies rekonstruēt viņa dzīvi.\nAngļu pirātu kuģa „Duke” sardzes matrozis pamanīja uguns zibsni uz neapdzīvotas salas Klusā\nokeāna dienvidu daļā. Nākamajā dienā kapteinis nosūtīja uz turieni bruņotu komandu. Vīri atgriezās\nar diviem pārsteigumiem – laivā viņi atveda kaudzi langustu* un kādu pinkainu radījumu. Būtne, kas\n1709. gada 2. februārī uzrāpās uz „Duke” klāja, pēc visa spriežot, bija cilvēks, taču izskatījās kā mežonīgs\nzvērs – kailām kājām un ietinies kazu ādās. Viņš bija ļoti satraukts un sākumā spēja murmināt vien\npusvārdos. Daniels Defo šo salinieku savā 1719. gadā izdotajā romānā nodēvēja par Robinsonu Krūzo.\nTaču Robinsona īstais vārds bijaAleksandrs Selkirks. Viņš bija skots, septītais dēls kāda kurpnieka ģimenē,\ndzimis Loverlargo ciematiņā netālu no Edinburgas. Uz vējainās Masatjeras salas, kas atrodas Huana\nFernandesa arhipelāgā 650 kilometrus no Čīles, viņš bija pavadījis četrus gadus un četrus mēnešus.\nViņš bija tik vientuļš, cik vien vientuļš var būt cilvēks. Grāmatā minētais Piektdienis patiesībā neeksistēja.\nSelkirks arī nebija cietis kuģa avārijā, kā bija noticis ar viņa līdzinieku romānā.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2013\/2014"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Pēc nebeidzamiem strīdiem\nar kapteini viņu vienkārši izsēdināja nekurienē, tāpēc viņam nācās bezpalīdzīgi noskatīties, kā kuģis pazūd\naiz horizonta. Selkirkam atstāja vien segu, nazi, cirvi, šauteni, navigācijas instrumentus, katlu, tabaku un\nBībeli. 300 gadus pēc šī notikuma zinātniekiem izdevies rast pilnīgāku priekšstatu par laiku, ko Selkirks\npavadīja uz salas. Viņi apgalvo, ka noskaidrojuši, kur un kādos apstākļos viņš ir dzīvojis. Pētnieki atraduši\nviņam piederējušos priekšmetus. Saglabājušās liecības arī par viņa turpmāko dzīvi. Īstā Robinsona tēls\nnebūt nav glaimojošs, taču ļoti raksturīgs tā laika jūras klejotājiem.\nSelkirks bija jūras laupītājs. Dzimis nelabvēlīgā ģimenē, viņš jau 17 gadu vecumā aizlaidās\njūrā. Sirojumos pa Vidusjūru un Karību jūru viņš aplaupīja Spānijas jūras braucējus. Nebūdams\ndumjš, viņš ātri uzdienējās līdz stūrmaņa pakāpei, taču viņu iegāza nesavaldīgais raksturs.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2013\/2014"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Cilvēki viņu, šķiet, ne visai ieredzēja – varbūt tieši tāpēc vīrs tik stoiski izturēja salas vientulību.\n2009. gadā tika publicēti ekspedīcijas pa Selkirka pēdām rezultāti. Robinsona pētnieka Daisukes Takahaši\nun Skotijas Nacionālā muzeja arheologa Deivida Koldvela komanda vairāk nekā mēnesi pārmeklēja salu,\nkura 1966. gadā oficiāli nodēvēta Robinsona Krūzo vārdā. Tā joprojām ir nomaļa un vientulīga vieta,\nun tur mīt 600 iedzīvotāji – vairākums ir langustu zvejnieki. Pa divām nebruģētām ielām pārvietojas labi\nja pāris duču automašīnu, te nav neviena restorāna, neviena kroga, šad un tad pa ceļam no Galapagu\nsalām uz Ugunszemi piestāj kruīza kuģi. Kādā ērkšķu krūmu iekļautā klajumā vulkāna nogāzē gandrīz\n300 metru augstumā arheologi sāka pārmeklēt vietu, kur vajadzēja atrasties Selkirka apmetnei. Viņš\nnebija apmeties piekrastē, tas būtu pārāk riskanti. Viņam bija jābaidās nevis no cilvēkēdājiem kā Defo\nRobinsonam, bet gan no spāņiem. Tie būtu viņu nogalinājuši vai pārdevuši verdzībā.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2013\/2014"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Sijājot izrakumos\nizcelto zemi, arheologi ieguva vistiešāko Selkirka klātbūtnes pierādījumu: 1,6 centimetrus garu stūrainu\nbronzas gabaliņu ar smailu galu. Metāla priekšmetam bija tāda pati forma kā cirkuļa apakšējai daļai,\nkas, kā zināms, bija Selkirka navigācijas instrumentu komplektā. Visticamāk, viņš cirkuli izmantojis kā\ndarbarīku un to salauzis. Metalurģiskās pārbaudes rezultāti liecina, ka metāls varēja būt iegūts Kornvolā.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2013\/2014"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "No apmetnes līdz stāvā kalna virsotnei Selkirkam bija jārāpjas vēl 300 m – tur atradās novērošanas\npostenis, kurā viņš uzturējās stundām ilgi. Pamanījis buras, vīrs žigli izsvēra – draugs vai ienaidnieks?\nVai aizdegt signāluguni vai labāk palikt nepamanītam? Viņš redzēja vairākus kuģus, divi spāņu burinieki\npat piestāja krastā. No tiem viņš laimīgi paglābās. Visgrūtākie bija pirmie astoņi mēneši. Selkirks krita\ndepresijā. Taču kādā brīdī pirāts sāka pamazām iekārtoties. Izrādās, ka no visām okeāna salām viņam bija\npatrāpījusies šādai eksistencei vispiemērotākā. Drīz vien Selkirks jutās daudz labāk nekā jebkad agrāk un\npēc tam. Viņš bija ieslodzīts un pilnīgi brīvs. Salas klimats gandrīz visu cauru gadu bija maigs un sauss,\nte nemājoja indīgi un bīstami zvēri, saldūdens bija pieejams straumēm. Piekrastē gulšņāja resni roņi,\nlagūnā mudžēja langusti un dažādas zivis, bet uz zemes zēla un plauka dažādas meža ogas, zālītes un\nkāds augs, kas garšoja kā kāposts. Selkirks nebija pirmais cilvēks, kurš bija šeit iekārtojies uz palikšanu.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2013\/2014"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "1574. gadā spāņu pirmatklājēji te ieviesa kazas, citi kuģi atveda kaķus un žurkas, arī rutkus un pastinakus.\nDzīvnieki savairojās, bet cilvēki uzturējās tikai reizumis. Selkirks pieradināja kaķus, lai tie sargātu viņu no\nžurkām, kas naktīs skrubinājās gar kājām. Par sporta veidu kļuva kazu dzenāšana – viņš iemanījās skriet\nātrāk par tām un notriekt tās zemē. Daudzas viņš atlaida brīvībā, bet, kā vēlāk stāstīja saviem glābējiem, 500 kazas viņš nokāva gaļai un ādām un katru no tām reģistrēja piezīmju grāmatā. Komunikācijas\nvajadzībām Selkirks lasīja Bībeli, viņš lūdzās, meditēja un dziedāja psalmus. Saviem atbrīvotājiem viņš\nvēlāk atzinās, ka nekad nav bijis krietnāks kristietis kā šeit. Taču viņš šauboties, vai jelkad atkal tāds būs.\nTrīsdesmitgadnieka veselība bija stiprāka nekā jūrniekiem, kas viņu atrada. Puse kuģa komandas\npēc mokošā ceļa no Anglijas sirga ar cingu**. Turpretī Selkirks bija sprigans kā kazlēns. Āda uz pēdām\nbija tā sabiezējusi, ka pa akmeņaino vulkāniskās salas virsmu viņš pārvietojās ātrāk nekā kuģa komandas\nsuns. Apavus viņš sākumā necieta. Tāpat kā slavu.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2013\/2014"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Gandrīz trīs gadus Selkirks kuģoja pa pasauli ar pirātiem, kuri bija viņu izglābuši. Viņi devās\nuzbrukumos, laupīja un šantažēja, turklāt darīja to ar kroņa svētību, jo viņu upuri taču bija tēvzemes\nienaidnieki. 1711. gada nogalē salinieks ar salaupīto bagātību atgriezās Anglijā. Viņš acumirklī kļuva\nslavens, krogos mainot savus stāstus pret dzērieniem un ēdieniem. Iespējams, ka šādi viņu iepazina\narī Daniels Defo. Tomēr cilvēku pasaule Selkirkam nepatika. Vīru vajāja ilgas pēc salas. Kāds žurnālists citēja viņa teikto: „Man tagad pieder 800 mārciņas, taču es vairs nekad nebūšu tik laimīgs kā toreiz,\nkad man nebija ne plika graša.” 1721. gada 12. decembrī Selkirks nomira 45 gadu vecumā. Viņš tika\nguldīts jūras klēpī. Tobrīd „Robinsons Krūzo” jau bija kļuvis par bestselleru, un Defo romāna slava nav\nmazinājusies līdz pat šodienai. Tomēr viena Selkirka mīkla nav atrisināta joprojām. No ceļojumu piezīmēm\nizriet, ka vientuļnieks uz Masatjeras rakstījis dienasgrāmatu. To kādā vēstulē apstiprina arī viena no viņa\natraitnēm. Taču kur palikušas šīs piezīmes? Drīz pēc Selkirka nāves viņa pieraksti nokļuva Skotijas bagātākā augstmaņa – Hamiltonas hercoga – īpašumā. Kad viņa pēctečiem 19. gadsimtā savajadzējās\nnaudu, viņi „Christie’s” izsoļu namā Londonā pārdeva gleznas un retumu kolekcijas, no kurām lielākā daļa\npārgāja jaunās Vācijas impērijas īpašumā. Tāpēc pilnīgi iespējams, ka īstā Robinsona dienasgrāmata\nmeklējama Berlīnē – kādā aizmirstā Valsts bibliotēkas plauktā.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2013\/2014"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Man Rūdolfs Blaumanis liekas dievišķs un gribas, lai arī citi to sajūt, un es esmu gatava stāvēt\nuz ausīm, lai parādītu vēl kādiem simtiem cilvēku, cik tas ir nozīmīgi un skaisti. Blaumanim būtisks ir kas\ncits – ir sadzīves taisnība un lielā taisnība. Jauno Indrānu taisnība un motivācija ir pagātnē un nākotnē.\nKaut vecajam Indrānam arī pieder lielā pasaules taisnība (es nošķīru tos Indrānus, kas pilda manu maku,\nno tiem, kas iepriecina manu sirdi), viņš nav spējis dzīvē iemiesot varbūt sadzīviski sīko, bet varbūt\nvisbūtiskāko taisnību – mīlēt pats savu bērnu.\nLugā vēlos izcelt to, ka cilvēku nevēlēšanās vai nespēja runāt par svarīgo un sāpīgo galu galā\nnoved pie ļoti nopietnām nelaimēm. Indrāni būtībā ir luga par karu vienas ģimenes robežās, par to, cik\nsmagi un reizēm neiespējami ir sakārtot attiecības vistuvāko cilvēku lokā. Lugas konflikts ieguvis asu un\nmūsdienīgu skanējumu. Luga par nepieciešamību saprasties.\n",
+  "KLASE": 12,
+  "MACIBU_GADS": "2013\/2014"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Indrāni man ir pirmais Blaumaņa un arī klasikas iestudējums. Tādēļ tas ir ļoti liels izaicinājums – strādāt\nar materiālu, kas man ir ļoti mīļš, un arī vairāki šīs lugas iestudējumi man ir ļoti patikuši, un tomēr ceru, ka\nman izdosies šajā izrādē atrast kaut ko savu. Veidojot izrādi, liekas ļoti būtiski pētīt tieši Nacionālā teātra\niestudējumu tradīciju, jo šī luga runā par paaudzēm, kuras viena no otras pārmanto ne tikai savu iekopto\nzemi, bet arī mūsu nācijai biedējoši pazīstamu attiecību modeli, kas inficēts ar izteiktas paštaisnības,\nneizrunāšanās, neuzklausīšanas, otra nedzirdēšanas „vīrusu”. Tas ir rosinājis daudzus teātra māksliniekus\nradīt savus Indrānus, liekot atšķirīgus akcentus šīs ģimenes attiecību atspoguļojumā. Katrs no šiem\niestudējumiem ir radījis savu versiju par Latvijas laukiem.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2013\/2014"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Es nebiju nekāds Blaumaņa fans un joprojām līdz galam neesmu izlasījis viņa kopotos rakstus\nun arī Līvijas Volkovas Blaumaņa zeltu ne… Man Blaumanis bija izaicinājums tieši tādēļ, ka par viņu tiek\nmācīts – viņš ir ģeniāls. Sākot strādāt pie Indrāniem, man likās, ka es nupat, nupat atradīšu pierādījumus,\nka nemaz tik dižs tas Blaumanis nav. Bet man īsti neizdevās. Blaumanim ir tik dzelžaina struktūra, viņš\ntomēr ir profesionāls dramaturgs – man kā režisoram nebija brīvas rokas. Es nevarēju visu izdarīt pa\nsavam. Viņš man neļāva tik ļoti aizstāvēt Indrānu jauno paaudzi, kaut arī es ļoti gribēju. Bet es ļāvos. Es\nvispār bieži ļaujos. Jo katrs no izrādes dalībniekiem var pavērst iestudējumu vienā vai otrā virzienā. Man\nnav strikta sākuma uzstādījuma.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2013\/2014"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Labvēlīgas vides veidošana kultūrpolitikai reģionos ir atkarīga no vairākiem priekšnoteikumiem:\nuzticēšanās un spējas sastrādāties ar līdzīgi domājošajiem, piedāvātās idejas veiksmīgas īstenošanas\nun padarītā darba kvalitātes. Kultūras slānis neveidojas pats no sevis, tas jārada un jāatspoguļo – vismaz\nnovērtējot padarīto. Kāpēc tas svarīgi? Pašvērtējumam. Novērtējumam un salīdzināšanai.\nKultūrvide ir pamats, uz kā stāvēt visu radošo profesiju pārstāvjiem, kultūras produkts, vai tā būtu\nneliela dzejas grāmata, mūzikas festivāls vai starptautiska rakstura konference, izstāde vai koncerts arī\nnedrīkstētu izčākstēt kā sniegs pavasara saulē, jo faktiski visu šo kultūrslāni veido pašu pelnīta nauda.\nTāpēc visgrūtāk īstenot kādu ideju ir tad, ja idejas autors nerod kopīgu valodu ar finansētāju.\nKultūrslānis veidojas neviendabīgi atkarībā no cilvēku prasmes pārliecināt, pierādīt un argumentēt.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2013\/2014"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Grāmata, dievnams, teātris, deja, glezna, ēdamais dzintars, koncerts, tūrisms – šādā vai citādā\nkārtībā varētu grupēt Latvijas jeb ārpus galvaspilsētas kultūrvidē radītos kultūras produktus. Pievienotā\nvērtība šim kopumam būtu jāmeklē ārpus nozares, un kultūras aktivitātēs jāiesaista visi iedzīvotāji no\npirmsskolas līdz sirmam vecumam – katrā apdzīvotā vietā ir jānotiek nemitīgai kultūras kultivēšanai.\nJa izdevējam, draudzei, diriģentam un kultūras komisijām, suvenīru ražotājiem, telpu iznomātājiem\nizdodas vienoties kopīgā redzējumā, kā radošumu pārvērst precē un produktā, reģioni kļūst interesanti. ",
+  "KLASE": 12,
+  "MACIBU_GADS": "2013\/2014"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Mazas valsts ilgtspējīgs kultūras modelis ir pavisam vienkāršs – ziņkārīgi tūristi, laimes meklētāji,\ndzimtas sakņu pētnieki, cilvēki, kuri lūkojas, kas Latvijā notiek. Ieguldot kultūrā, mums atveras vārti\nkultūrtūrismam, interesei par valsti ar sarežģītu pagātni. Aizbraucot no Latvijas, tūrists, savā valstī ieejot\ngrāmatu veikalā, varbūt pamana, ka tur plauktā stāv laba, no latviešu valodas tulkota grāmata, kas nu jau\nir netieša saikne ar Latvijā gūtajiem iespaidiem. Pamazām, tomēr būvējama realitāte.\nVar lūkoties pēc atbalsta ārpus valsts, un to arī daudzi radošo profesiju pārstāvji dara. Vieniem\nizdodas, citiem ne. Kāpēc kultūrai būtu nepieciešams lielāks finansējums, runāts daudz un parasti visai\nskaļi. Zemapziņā mums ir un būs dusmīgi sarauktas pieres ikreiz, kad naudas nepietiks.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2013\/2014"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Ventspils ir viena no lielākajām ostas pilsētām Latvijā. Tā atrodas Baltijas\njūras krastā un ir nozīmīga ar savu neaizsalstošo ostu. Pilsētas nosaukums\ncēlies no Ventas upes, kas plūst cauri pilsētai. Ventspils ir sestā lielākā pilsēta\nLatvijā.\nVentspils ielas, parkus, skvērus, pagalmus rotā košas skulptūras, kas\nveidotas no dažādu šķirņu puķēm. Tur ir mīļa zaķu un pīļu ģimene, raibas\nzivtiņas, sarkanas mārītes, ziedu pulkstenis un milzīga puķu govs, kas sagaida\npilsētas viesus, kuri iebrauc pilsētā. Ielās un parkos sastopamas arī govis, kuras\nir apgleznojuši mākslinieki.\nPēc aktīvas atpūtas Bērnu pilsētiņā un Ūdens piedzīvojumu parkā var\ndoties braucienā ar mazbānīti vai kuģīti „Hercogs Jēkabs”.\nVakaros iespējama zvaigžņu un planētu vērošana Latvijā vienīgajā\ndigitālajā planetārijā.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2014\/2015"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Liepāja ir trešā lielākā pilsēta Latvijā un atrodas Baltijas jūras piekrastē\nstarp Baltijas jūru un Liepājas ezeru.\nPilsētas pludmalē ir baltākās un smalkākās smiltis pasaulē. Pēc vētras jūras\nviļņi kopā ar aļģēm un gliemežvākiem pludmalē izskalo dzeltenīgu dzintaru.\nKanālmalā var apskatīt milzīgu dzintara pulksteni, kuru izveidoja no 50 litriem\ndzintara gabaliņu. Tos saziedoja Liepājas iedzīvotāji. Arī pasaulē garākās\ndzintara krelles glabājas Liepājas Amatu mājā.\nLiepāja ir viens no Latvijas kultūras centriem. Pilsētā ir Latvijā vecākais\nteātris un katedrāle, kurā skan pasaulē lielākās mehāniskās ērģeles.\nLiepāja ir daudzu Latvijā populāru mūziķu pilsēta. Te atrodas mūziķu slavas\naleja, kur katrs apmeklētājs var samērot savu plaukstu ar mūziķu plaukstas\natlējumu bronzā. Turpat blakus savu spēlētāju gaida lielākā ģitāra, bet Piejūras\nparkā atrodas lielākās bungas Latvijā. ",
+  "KLASE": 3,
+  "MACIBU_GADS": "2014\/2015"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "23. novembris pirms četriem gadiem bija parasta auksta diena. Darja nemaz\nnevarēja iedomāties, ka todien notiks negaidīts brīnums.\nViss sākās ar to, ka Darja gribēja ielaist mājā savus no pastaigas pārnākušos\nsunīšus. Meitene atvēra durvis un ieraudzīja, ka uz sliekšņa kopā ar viņas mīluļiem\nsēdēja mazs, pūkains kamolītis. Darja ienesa to iekšā. Izrādījās, ka tas ir putnu\nmazulis.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2014\/2015"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Darjas ģimene nesaprata, kas tas par putnu. Nākamajā dienā viņi uzzināja, ka\ntas ir pūču dzimtas pārstāvis, turklāt mazākais no pūcēm – apodziņš.\nSākumā ģimene gribēja apodziņu atdot zoodārzam, bet tomēr atstāja viņu mājās.\nApodziņu nosauca par Pifu.\nDarja kopā ar vecāko māsu internetā sameklēja informāciju, kā šādus putniņus\nturēt mājas apstākļos, lai viņi justos labi. Bērni arī uzzināja, ko ēd apogi. Galvenā\nbarība ir gaļa. ",
+  "KLASE": 3,
+  "MACIBU_GADS": "2014\/2015"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Tētis kopā ar brāli izgatavoja ērtu būri ar vairākiem nodalījumiem.\nVakarā, kad visa ģimene bija mājās, apodziņš Pifs drīkstēja atstāt būri un\nlidināties pa visu māju. Ja Pifs nejutās paēdis, viņš pielidoja pie kāda no cilvēkiem\nun knāba ausīs. Tas bija tik aizraujoši! Darja gribēja redzēt, kas notiks, ja Pifam\nistabā noliks palielu trauku ar ūdeni. Izrādījās, ka apodziņam ļoti patika plunčāties\nūdenī.\nPifs drīz vien kļuva par ģimenes lutekli. Par jauno iemītnieku priecājās arī\nģimenes četrkājainie draugi.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2014\/2015"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Riks un Miks bija atšķīrušies no pārējiem bērniem un klīda pa mežu, lai veiktu uzdevumu – sasietu\nslotiņas.\n– Kādus zarus lai laužam, – pieri savilcis, īgni purpināja Riks, – neviens jau neko nepateica, – tad, kā no\nsevis atgaiņādams atbildību, atmeta ar roku un savu monologu pabeidza ar vārdiem: – Man par slotiņu\nsiešanu nav ne mazākās sajēgas.\n– Man arī nav nekādas saprašanas, – pie sevis nomurmināja Miks. – Iesim pie citiem un pajautāsim.\nTe, kur gadījusies, kur ne, zēnu priekšā nostājās izspūrusi meitene, kurai rokas un kājas bija\nsaskrāpētas, bet drēbes saplēstas.\n– Vai jūs apmaldījušies esat, ka te mīņājaties uz vietas? – meitene jautāja.\n– Kā tā – mīņājamies? Vai tad tu tik labi pazīsti šo apkārtni? – neuzticīgi, caur pieri uz meiteni blenzdams,\njautāja Riks. ",
+  "KLASE": 6,
+  "MACIBU_GADS": "2014\/2015"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Jā…– gari stiepjot īso vārdiņu, nelaipni norūca Paija. Priecīgs, ka pats liktenis viņiem atsūtījis palīdzību, Miks draudzīgi paskatījās uz meiteni un paskaidroja: – Tu varēsi mums palīdzēt atrisināt uzdevumu, ar ko paši netiekam galā. Risināt šāda veida sarunas Riks uzskatīja zem sava goda. Viņš nepieļāva iespēju kādam atzīties, ka kaut ko nezina vai nespēj, tādēļ steigšus pārtrauca Miku: – Miks pārspīlē. Tā nepavisam nav. Lieta tāda – mēs gribam sasiet pirtsslotas no pašiem labākajiem un piemērotākajiem zariem, lai vēlāk ietu pirtiņā. Paija, ne mirkli nedomādama, iesaucās: – Es jums varu palīdzēt! Jums būs tādas slotas, ar kurām neviena cita nevarēs sacensties. Paija metās uz priekšu, zēni steidzās pakaļ. Bērni nonāca pavisam savādā mežā, kur auga neredzēti koki ar plati izplestiem zariem. Lapas līdzinājās milzīgiem vēdekļiem. Tikai tie nebija koki, bet latvāņi*",
+  "KLASE": 6,
+  "MACIBU_GADS": "2014\/2015"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Smejoties zēni trenkāja viens otru, un, kamēr viņi izklaidējās, Paija veikli plūca latvāņu lapas\nun sēja saišķos. Ap vietu, kur tās bija jāsaņem saujā, viņa aplika samtainās māllēpenes. Paija\ntīksminājās par paredzamo joku, ko viņa grasījās izspēlēt ar abiem vientiešiem, un tiem jautri\nuzsauca:\n– Vai tad nepietiks dauzīties? Vai jums slotas nav jāsien?\n– Par ko tu runā? Par kādām slotām? – abi reizē iesaucās un apjukuši raudzījās meitenē.\n– Jūs gaida pirtiņa. Jūs tikai trenkājat viens otru, bet darāmais jums nemaz nav prātā. ",
+  "KLASE": 6,
+  "MACIBU_GADS": "2014\/2015"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Sapratuši, ka darbu nav paveikuši un laiks ir velti izšķiests, abi neziņā nemierīgi dīdījās uz vietas.\nPirmais atguvās Riks. Pieglaimīgi viņš uzrunāja meiteni, kura nebēdnīgi vicināja rokās savu\nmeistardarbu.\n– Tev taču nevajag divas slotiņas. Atdod vienu man! – Riks teica un, roku izstiepis, tuvojās meitenei.\n– Nu, labi, izpalīdzēšu! Šīs slotas pērs jūs stiprāk, nekā spējat iedomāties!\nPārņemti no atvieglojuma sajūtas, ka grūtais uzdevums izpildīts – slotas sasietas, zēni pat neievēroja\nPaijas zīmīgos vārdus. ",
+  "KLASE": 6,
+  "MACIBU_GADS": "2014\/2015"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Kāds ir tas pamudinājums, kas beidzot liek saņemties un uzrakstīt par savu bērnību?\n– Vispirms – tas nav atmiņu stāsts. Taču vienlaikus jāatzīst, ka nevajadzēja neko izdomāt, mana\npieredze bija pilnīgi pietiekama, lai varētu radīt romānu. Tā varoņiem ir reāli prototipi, arī manas ģimenes\nlocekļi. Tomēr nevēlos to izziņot kā autobiogrāfiju. Distancējos, jo gribu, lai lasītājs to uztver kā literāru\ndarbu, ko vērtēju augstāk nekā atmiņu stāstus – no žanru hierarhijas viedokļa.\n– Līdz šim jūs tiešām esat vairījusies runāt par privāto dzīvi. Kaut kas, protams, ir izskanējis\nNoras Ikstenas grāmatā. Un tomēr – no driskām, ko zinām, spilgtākos notikumus atpazīstam arī\njaunajā grāmatā, un distancēties, iedomāties, ka Laura nav Māra, ir ļoti grūti.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2014\/2015"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Tas arī nav vajadzīgs! Godīgi sakot, man nav bijis tādas īstas pašapceres par šo darbu, tāpēc nezinu,\nko par to domāju. Viss rodas tā spontāni, mūsu sarunas gaitā. Šķiet, tīri zemapzinīgi gribu distancēties\ntāpēc, ka robeža starp mani un meiteni romānā patiesībā ir ļoti maza. Man ir piemērs – fragmentu par vīru\nar iesauku Svētais Pēteris iedevu izlasīt cilvēkam no manas puses. Viņam tas gabaliņš ļoti patika, bet viņš\nteica – zini, tev tur ir viena kļūda, Svētajam Pēterim sunīša nebija. Un es mēģinu nodrošināties pret šādiem\niebildumiem.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2014\/2015"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Ka nedrīkstētu savā daiļdarbā izmantot interpretāciju?\n– Jā. Es sapratu, ka man nevajag šo lieko diskusiju. Un no tās meitenes distancējos, bet vienlaikus\narī identificējos. To sarežģīti izstāstīt. Kas attiecas uz galvenajiem, man tuvākajiem, mīļākajiem cilvēkiem,\ntur ir tāda... ļoti tuvu īstenībai un dažkārt – pilnīga sakritība. Protams, varbūt meitenītes redzes leņķis viņus\ndeformē, jo bērna uztvere nav tāda kā pieaugušajam. Un arī, es teiktu, mīlestības klātbūtne. Jo, protams,\nskatos uz viņiem ar mīlestību... Turklāt, ja saproti, ka radi literāru tēlu uz savas pieredzes bāzes, ir daudz\nlielāka brīvības izjūta. Drusciņ sajauc realitāti – noliec vienas mājas pie upītes, kas īstenībā tur nebija,\notras pie dzelzceļa, un neviens nevar piesieties.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2014\/2015"
+ },
+ {
+  "TEKSTA_FRAGMENTS": " Cilvēki, lasot, atļaušos teikt, līdzīgas atmiņas – Tūves Jānsones Tēlnieka meitu vai Vizmas\nBelševicas Billi –, ir pateicīgi nevis par dokumentāru precizitāti, bet godīgām bērna sajūtām.\nTieši šīs godīgās atmiņas noloba dvēseli un liek cilvēkam atcerēties notikumus pašam no savām\nmazajām dienām.\n– Jā, vienīgi šī grāmata nav tik harmoniska kā Tēlnieka meitas atmiņas. Es pat teiktu, ka apakšstrāva\nir diezgan dramatiska, traģiska... Redziet, saturs mani ir pavadījis visu dzīvi. Es tiešām neesmu par\nto stāstījusi, jo negribēju sīknaudā izdāļāt fondu, kas manī. Tam bērnam patiesībā ir laimīga bērnība.\nVismaz viņš to izjūt kā laimīgu. Viņam ir tāda vitalitāte, vēlēšanās dzīvot, prieks par visu pasauli... Un\ntomēr – briesmīgie piedzīvojumi gan ar krustmāti, gan citiem cilvēkiem no Sibīrijas barakas... Ir vienkārša\npatiesība, ka uz melna nedrīkst rakstīt ar melnu. Un es atradu variantu, lai cilvēkam nebūtu smagi lasīt. Arī\npar šausmīgo centos rakstīt viegli, un vienīgā iespēja, kā to izdarīt, ir izteikties ar bērna muti.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2014\/2015"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Vai jums, rakstot šo darbu, izkristalizējās sajūtas, ka jebkurš bērns, lai cik mīloši cilvēki\nviņam būtu apkārt, tomēr ir kā opozīcijā, jo nevar iekļūt pieaugušo pasaulē? Viņš dzīvi vēro kā no\nkupejas augšējā plaukta.\n– Tam varētu piekrist. Bet bērniņam, kurš piecu gadu vecumā atgriežas no Sibīrijas, ir milzīga\npieredze. Labi, viņš nekad mūžā nav redzējis ābolu, un dārzs Latvijā viņam kļūst par tādu kā Paradīzes\ndārzu, bet viņu ir kristījušas lietuvietes, barojusi gruzīniete – tas izklausās pēc mitoloģijas.\n– Pēc Svētajiem rakstiem.\n– Vai ne? Un tā nu gan ir skaidra patiesība! Ir arī ebreju krustmātes stāsts, ko arī visu dzīvi nēsāju\nlīdzi, domājot, kad to varēšu cienīgi pastāstīt.\n– Jūs runājat par operdziedātāju Asju no Londonas?\n– Jā. Labi, ka Norai to esmu stāstījusi grāmatā, ko viņa rakstīja par mani, Zīdtārpiņu musināšana,\ncitādi teiktu, ka saceru teiksmas. Patiesībā par katru no tiem cilvēkiem varētu romānu uzrakstīt. It īpaši\npar Asju. Mēģināju ļoti sarežģīti – krusteniski, šķērseniski aužot, kā komponējot – ar vadmotīviem,\natkārtojumiem, poētisku valodu, drausmīgu slengu un žargonu, dialogiem, tēlojumiem kopā saaust tā, lai\nnav tikai diegi un kamoli, bet raksts! Man tas ir jauns žanrs – romāns. Dažs labs saka – kā tu, dzejniece\nbūdama, varēji romānu uzrakstīt?!",
+  "KLASE": 9,
+  "MACIBU_GADS": "2014\/2015"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "– Jums tas ir sanācis dzejisks.\n– Un arī dramatisks! Būtībā esmu lietojusi visu savu žanrisko arsenālu.\n– Vai tiešām to sauca par Noasa baraku?\n– Nē! Drīzāk tā bija kā Bābele.\n– Noass skan skaistāk – tā ir izglābšanās, kur cits citam, lai cik dažādi būtu, nedara pāri.\n– Jā, tie, kas paliek pāri pēc šausmīgajiem grēku plūdiem. Bet es to aizstāju ar Bābeles torni. Laura\nlielās, ka protot nez cik valodu. Ne nu prot, nekā! Dzirdējusi gan ir.\n– Vai jūs kādu no barakas cilvēkiem vēlāk esat satikusi?\n– Kad gadu pēc mūsu atgriešanās no Sibīrijas atbrauca arī vecāmāte, pie viņas sāka braukt\ndraudzenes, dažas tā kā pa miglu atcerējos – kādus sejas pantus, ķermeņa valodu... Un es, protams,\npiesūcos ar stāstiem, kas nebija manis pašas reālā pieredze. Klausījos vaļā muti, ik reizi saspringstot,\nausis spicējot pie teikuma – kuš, bērns klausās... ak, nu, viņš vēl par mazu, nesaprot! Un tādi skanēja\nbieži. Un interesantākais – es arī izlikos, ka neko nesaprotu.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2014\/2015"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "– Romānu sauks Laura? – Nē, Pieci pirksti. Tā ir Lauras māja ābelē! Vajadzība pēc tās radās, kad pieminētais Stasis bija uztaisījis štābu, kā visi puikas to dara, un man arī, tas ir, Laurai, vajadzēja... Dārzā bija daudz vecu ābeļu, un vienai no stumbra nāca tieši pieci lielie zari – tie veidoja tādu kā sauju. Ierāpties nebija grūti, viens vecs spilvens bija trāpījies istabas augšā, no kura spalvas lidinājās. Laura domāja, ka tas ir ļoti labi, jo tad putni domās, ka viņa arī ir putns, un draudzēsies, neuzskatīs par svešinieci. Pieci pirksti nāk arī norādē – tu nedrīksti par Sibīriju nevienu vārdu runāt, tas tev jāzina kā pieci pirksti. Tas nu bija iekalts. Nedrīkst. Nevienam. Neko. Un Asjai bija salauzti pieci pirksti. Katrai rokai. Tad vēl – Laurai patīk kļavas. Man arī patīk, ļoti! Tāpēc, ka viņām lapas ir kā pieci pirksti. Viņās ir kas cilvēcisks. Ar kļavu var sarokoties. – Sist pieci. – Jā! Un Laurai ir pieci gadi – uz katra pirksta pa vienam.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2014\/2015"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Kāpēc tieši Laura? Jums pašai ir tik spēcīgs vārds, ka atrast pienācīgu aizstājēju ir grūti. – Tas ir interesants stāsts. 1989. gadā biju Amerikā. Katrā pilsētā, kur uzstājāmies, palikām pa nakti pie kādas ģimenes. Es nonācu ļoti jaukā, kur mājasmātes māte bija 86 gadus veca, un viņas māsai Laurai bija 89 gadi. Viņas strīdējās, kura vedīs mani uz pasākumu, un māsa teica Laurai – nē, tu esi par vecu! Es vedīšu! Vakarā sākam runāties, un vecās kundzes saka – zināt, kāpēc mēs tieši jūs gribējām? Jo jūs esat no Slampes! Un, redzat, mēs arī! No kurām mājām? Kalnaķivuļiem? Nevar būt! Tās ir mūsu kaimiņos! Paga, vai tad Ģeņģeru Almu arī pazīstat? Saku: Alma ir mana vecvecmāmiņa! Man patika dzirdēt, ka Ģeņģeru Alma bijusi kārtīga saimniece, taisījusi viesības. Jutu lielu tuvību ar veco cilvēku tieši tāpēc, ka viņa bija saikne ar maniem senčiem. Interesanti – lugu Zemes nodoklis konkursam iesniedzu ar pseidonīmu Laura Kalnciema. Negribēju, lai vērtē kā Māras Zālītes darbu. Nu jā, un luga tajā konkursā vinnēja!",
+  "KLASE": 9,
+  "MACIBU_GADS": "2014\/2015"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "– Visi domāja, ka tūlīt iepazīsies ar jauno dramaturģi? – Bija vēl trakāk – kāds no žūrijas man klusītiņām teica, ka esot viena baigi labā luga, bet dramaturģe pilnīgi jauna. – Nu, griezīs pogas laukā? – Jā, pārspējusi mani. Olga Dreģe palīdzēja taisīt mistēriju – ieradās uz balvas pasniegšanu, tēlojot Lauru Kalnciemu. Vispār apstājos laikā, jo domāju – ja iznesīšu kritiķus cauri līdz tam, ka sāks recenzēt to darbu, viņi man to nekad mūžā nepiedos! – Ar viņiem jāsaglabā labas attiecības? – Tas man laikam nav izdevies, bet domāju, ka cilvēki var justies apvainojušies, un to es negribēju, spēlīti pārtraucu. Tā ka ar Lauras vārdu varu labi sadzīvot. Un atcerēsimies skaistos Petrarkas sonetus Laurai! – Tajos Laura ir mīlētas, apdziedātas sievietes simbols. – Jā, bet Laura jau arī kādreiz izaugs – no piecgadīgās meitenes. Par sievieti. – Daļēji grāmata ir ar misijas apziņu, jo tur ir arī laika grieži, tautas, cilvēku likteņi…? – Kad jau zināja, ka esmu dzimusi Sibīrijā, man bieži jautāja – kad vienreiz to uzrakstīsi? Teicu – nezinu, kad būšu tam gatava. Bet tas, ka uzrakstīšu, man bija skaidrs jau no pirmajiem bērnišķīgajiem šļupstiem literatūrā. Ar vārdiem nevajag mētāties. Vārdi ir enerģija. Neviens nav tukšs. Katrs nes vibrāciju. Skaņa ir fizikāls jēdziens, to var izmērīt. Un vārds nav tikai skaņa, bet skaņa ar jēgu, iedarbīgs – to zinām no buramvārdiem. Taču mēs tam neticam. Burtiski nogalinām cits citu ar vārdiem. Ļaunums meklē ceļus, un anonimitāte ir viens no melnajiem caurumiem.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2014\/2015"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Dailes teātrī piedzīvojusi pirmizrādi lietuviešu dramaturga Marjus Ivaškeviča luga Izraidītie. Un – izrāde ir lieliska. Tas ir it kā reālistisks stāsts par baltiešu emigrantiem, tā īstenībā ir filozofiska līdzība, kur tēli vienlīdz pārliecinoši funkcionē gan reālistiskā, gan metaforiskā līmenī. Kamēr publika tikai nāk un meklē savas sēdvietas, grupa Ryga zālē raida ritmisku mūziku visskaļākajos decibelos, bet aktieri skatuves dibenplānā imitē bāra atmosfēru. Daži no viņiem pat uzlēkuši uz bāra letes, kura vienlaikus būs jaunās dzīves skates mēle.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2014\/2015"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Mūzika neapšaubāmi ir\nagresīva, uzbrūkoša, bet arī iekšā ievelkoša, pat aizraujoša. Ja nebaidītos vulgarizēt, varētu teikt – kā\npati sarežģītā, mutuļojošā mūsdienu dzīve, ko var salīdzināt ar katlu.\nPar to, cik atšķirīgi dažādās kultūrvidēs – latviešu un lietuviešu – strādā viens un tas pats tēls,\nliecina izrādē vairākkārt atskanošā pavēle „Uz ceļiem!”, ar ko savu varu apkārtējiem demonstrē Laura\nDzelzīša atveidotais Vandals. Mums tā ir vienkārša pazemojuma zīme, lietuviešiem kā katoļticīgai\nnācijai – divkārša, jo uz ceļiem metas Dieva priekšā baznīcā. Tātad pavēles devējs sevi iecēlis Dieva\nvietā, veicot zaimošanas aktu. ",
+  "KLASE": 12,
+  "MACIBU_GADS": "2014\/2015"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Dailes teātra izrādē Izraidītie ir primitīva teātra valoda, kurā dominē dažādas intensitātes nepamatota agresija un publikai uzbrūkoši muzikālie efekti, tas viss papildināts ar efektīgu ārējo formu. Izraidītajos, kā mēdz teikt, ir pārāk daudz trokšņa, lai nolasītu izrādes vēsti. Piemēram, Dailes teātrī – smags poproks, kas grupas Ryga izpildījumā skan jau pirms izrādes, kā ansamblis tas profesionālā ziņā „izpildās” gana spēcīgi, taču izrādes jēgas kontekstā elementāri grauj labticīgā skatītāja psihi. Turklāt nevaru saprast, kādēļ man izrāde brūk virsū, ko es kā skatītājs esmu nodarījis, lai ar mani sarunātos tik primitīvā teātra valodā, kas – būsim atklāti! – aizgūta no astoņdesmitajiem gadiem.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2014\/2015"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Izraidīto „pārcelšanā” uz Rīgu būtiski transformējušies izrādes kultūrkodi. Runa ir par divām vienas frāzes nozīmēm – latviešu publikai grūti saprast, kādēļ varonis Vandals (Lauris Dzelzītis) kliedz „Uz ceļiem!” (atšķirībā no katoliskās Lietuvas, kur „Uz ceļiem!” nozīmē Kristus priekšā mesties ceļos, bet konkrētās izrādes sakarā iegūst pazemojošu izteiksmi – meties manā priekšā uz ceļiem!). Latviešu skatītājam Dailē dzirdētā pavēle ir tukši vārdi. Emigrācijas tēma ir vien veikla manipulācija ar skatītāju masām, jo visi alkst redzēt aktualitātes arī uz skatuves. Dailē vienkārši pietrūkst sava hita par emigrāciju – Dž. Dž. Džilindžers2 tādu šovu „uzblieztu”, ka par maz neliktos!",
+  "KLASE": 12,
+  "MACIBU_GADS": "2014\/2015"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "! Piedāvāju tēmu – Viļa Lācīša3 sociāli aso anekdoti Stroika ar skatu uz Londonu (2010). Nu, paklau: „Stroikā ar skatu uz Londonu stāstītājs ir jauns vīrietis, kurš strādā celtniecībā. Lasītāju gaida pārsteigumi, krimināla intriga un nopietnās pārdomās balstīti ironiski un apbrīnojami sirsnīgi spriedumi par Latviju un Angliju, par latviešiem un imigrantiem.”4 Kādēļ gan ne Izraidītie II?",
+  "KLASE": 12,
+  "MACIBU_GADS": "2014\/2015"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Šī izrāde ir rūpīgs lokalizācijas darbs – globāla darba imigrantu kultūra, balstīta nedrošībā un bailēs, sapņos un smagā fiziskā darbā, atstumtībā un asā vientulībā – visi šie komponenti tika dziļi emocionāli pavērti skatītājiem, kas gan palika tradicionāli vēsi un atturīgi, nereaģējot uz patiesiem aktiermeistarības šedevriem. Latvijas iedzīvotāju stāsti – darbs Īrijā, bet dzīve un atmiņas Latvijā – tika savienoti ar globālu kustību postpadomju pasaulē. Izrāde varbūt ir pat detektīvstāsts par puisi Benu, kurš, kā viņš pats domā, ticis izmests no savas dabiskās dzīves vides. Mēs taču ticam, ka ir kaut kur uz šīs pasaules mūsu dabiskā vide, kurai mēs piederam. Vai mēs varam arī nepiederēt?",
+  "KLASE": 12,
+  "MACIBU_GADS": "2014\/2015"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Varam, bet ļoti gribas tomēr kaut kur būt mājās – mēs, sabiedriskie dzīvnieki, meklējam savas alas, tumšas un siltas... un atrodam tās citu cilvēku domās, viņu spējā mūs saprast, pasargāt mūs no sevis. Izraidītie nav stāstījums par vulgaritātes iemiesojumu sporta biksēs – šis apģērbs kopš 90. gadu sākuma kļuva par popkultūras un jauniešu pilsētas svētdienu pastaigas tērpu. Mēs vairs nebaidāmies iekļūt telefona austiņu aizsargjoslā un nedzirdēt citus, bet tomēr tik ļoti baidāmies palikt vieni, it sevišķi cilvēku pilnā bārā. No daudzām vientulībām top iestudējums par sapņu sabrukšanu, par akūtām bailēm atrast ierastajā kaut ko šausminoši jaunu.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2014\/2015"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Cilvēks ilgi domāja un beidzot izdomāja: „Labāk būs, ja sacīšu, ka paklanījos Vējam. Lai Saule ir cik karsta būdama, kad Vējš sāk pūst, uzreiz laiks paliek vēsāks. Lai arī Sals stipri saldē, kad Vējš sāk pūst no dienvidu puses, pēc brīža paliek siltāks.” Pēc īsa brīža cilvēks sacīja: „Es paklanījos Vējam.” Saulei tas nemaz nepatika, un viņa piedraudēja cilvēkam: „To tu pieminēsi visu savu mūžu, ka Vēju atzini par labāku!” Vējš mierināja cilvēku, sacīdams: „Nebaidies ne no Saules, ne no Sala! Ja viņi gribēs tev ko ļaunu darīt, tad tikai piemini mani!”",
+  "KLASE": 3,
+  "MACIBU_GADS": "2015\/2016"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Vasarā Saule izlēma cilvēkam atriebties un vērsa savus starus uz cilvēku ar vislielāko spēku. Cilvēkam palika tik karsti, ka nekur glābties. Ne ārā, ne istabā nav spirgtuma. Jāiet ūdenī atvēsināties, bet cik ilgi tad ūdenī sēdēsi? Te cilvēks iedomājās par Vēju: „Kaut jel vējiņš sāktu pūst, nebūtu vairs tik karsti!” Tūdaļ Vējš sāka pūst no ziemeļu puses, un tajā pašā brīdī laiks kļuva vēsāks. Cilvēks atkal turpināja darīt savus darbus. Saulei bija jāatzīst, ka Vējš tomēr ir stiprāks.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2015\/2016"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Ziemā savukārt Sals gribēja atriebties cilvēkam. Viņš uzsūtīja tādu aukstumu, ka, pat istabā sēžot, bija kažoks jāvelk mugurā. Cilvēks atcerējās Vēju. Viņš sacīja: „Ja Vējš sāktu pūst, tad arī mākoņi staigātu un aukstums paliktu mazāks.” Drīz arī Vējš sāka pūst no dienvidu puses. Sacēlās sniegputenis, un aukstums kļuva mazāks. Nu arī Sals redzēja, ka Vējš ir varenāks.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2015\/2016"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Saule un Sals saprata, ka ir kļūdījušies. Stiprākais ir tas, kas nelielās ar savu spēku. Tikai darbā var redzēt, kam ir vairāk spēka. Kopš tā laika Saule, Sals un Vējš nestrīdas un ļauj cilvēkam strādāt.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2015\/2016"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Reiz sensenos laikos satikās trīs ceļa gājēji – Saule, Sals un Vējš. Viņi izlēma tālāk iet kopā. Pa ceļu iedami, viņi savā starpā sarunājās. Runātāji sprieda, ka stipram ir labi dzīvot pasaulē – lai ietu, kur iedams, visi no viņa baidīsies. Saule pārliecinoši teica: „Es esmu stiprāka par jums abiem.” Sals sadusmojās un atbildēja: „Nē, es esmu stiprāks!” Strīds kļuva arvien skaļāks.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2015\/2016"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "ļāks. Kā nu lai izšķir, kurš ir tas stiprākais? Tālāk ejot, viņi satika vienu cilvēku. Redzēdams trīs ceļa gājējus, viņš noņēma cepuri, paklanījās un gāja tālāk savu ceļu. Cilvēks nebija vēl necik tālu aizgājis, kad ceļa gājēji sauca viņu atpakaļ. Gājēji gribēja zināt, kuram gan īsti cilvēks paklanījies, jo neticēja, ka visiem trim. Satraukti par neskaidrību, viņi jautāja: „Saki, cilvēk, mums taisnību, kuram no mums trim tu paklanījies?”",
+  "KLASE": 3,
+  "MACIBU_GADS": "2015\/2016"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Cilvēks domāja, domāja un nezināja, ko atbildēt. Sacīt, ka paklanījies visiem trim, laikam nebūtu labi. Ja teiks, ka vienam, tad nevar zināt, kuram būtu labāk to teikt. Saule var stipri karsēt. Sals var stipri saldēt. Vējš var izkaltēt zemi. Kam nu dot to godu?",
+  "KLASE": 3,
+  "MACIBU_GADS": "2015\/2016"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Pirms vācu ierašanās Latvijā 12. gs. savā nozarē lielus panākumus ir sasnieguši latviešu rotu gatavotāji. Latviešu sudraba un bronzas, kā arī citu materiālu rotas šai laikā ir ļoti vērtīgas. Rīgā līdz pat 17. gs. strādā latviešu saktu kalēji, kuriem ir tiesības gatavot un tirgoties tikai ar pašu gatavotām saktām, gredzeniem un spraudēm. Latviešu saktu kalēju brālības1 šrāgas2 apstiprinātas 1512. gada 29. maijā. Tās nosaka, ka saktu kalēja amats jāmācās trīs gadus un pēc tam vēl vienu gadu jākalpo par zelli3",
+  "KLASE": 6,
+  "MACIBU_GADS": "2015\/2016"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Tad amata vecākā mājā jāizstrādā meistara darbs – trijkāršā sakta, platā sakta un gredzens. Ja darbs ir kārtīgi veikts, uzņem amata meistaros. Kad saktu kalējs iestājas amatā, viņam jāsamaksā sešas Rīgas markas par svecēm, amata brāļi jāuzcienā ar mucu alus un šķiņķi, kā arī jāievēro amata noteikumi. Latviešu saktu kalēju darbs šai nozarē beidzas 17. gs., kad to pārņem vācu zeltkaļi, kas turpmākajos gados pārkāpj zeltkaļu šrāgu pamata noteikumu – nedrīkst latviešu sudraba saktās ievietot krāsotos stiklus.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2015\/2016"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Maija grāfa svētkus Rīgā sāka svinēt 14. gadsimtā. Svētku dienas bija 30. aprīlis un 1. maijs. Galvenie svētku rīkotāji bija melngalvji1 un Lielā ģilde2 . Tos sagaid__ja parāde zirgos, tad sekoja karaspēles un bruņinieku sacensības. Dalībnieki demonstrēja gatavību aizstāvēt pilsētu pret iebrucējiem un centās pilsētniekos stiprināt kareivīgu garu. 1. maija rītā jaunekļi pie savas līgavas mājām novietoja bērziņus un izgreznoja tos ar raibām lentēm, vainadziņiem un dāvanām. Par Maija grāfu kļuva tas, kurš spēja uz sava šķēpa vienā piegājienā uzdurt trīs vainagus, kas bija novietoti uz tauvas starp diviem stabiem. Viens vainags tika pašam uzvarētājam, otrs – Lielās ģildes vecākajam, trešais – Maija grāfa izredzētajai. Otrajā svētku daļā bija mielasts un dejas, ko pavadīja bungas, trompetes un bazūnes. Viduslaikos pēdējo reizi svētki tika svinēti 1542. gadā.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2015\/2016"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "2001. gadā SIA „Rīgas nami” ar Rīgas domes atbalstu atsāka rīkot Maija grāfa svētkus, lai godinātu pavasari un mīlestību. Šo svētku laikā notika amatnieku tirdziņš un seno amatu demonstrējumi, risinājās bruņinieku turnīri, mucu ripināšanas sacensības, divkaujas ar maisiem uz baļķa. Svētki nebija iedomājami bez košiem seno laiku tērpiem, karnevāla un plašas koncertprogrammas. Lai iegūtu Maija grāfa titulu, pretendentam bija jāveic dažādi uzdevumi, piemēram, jāvelta dzeja daiļajai dāmai, ar zobenu jāpāršķeļ kāpostgalvas, uz rokām jātur sava sirdsdāma, kā arī jāšauj ar loku un b__ltām. Maija grāfa titulu ieguva sabiedrībā pazīstami cilvēki: vijolnieks Raimonds Ozols, SIA „Rīgas dārzi un parki” direktors Agris Kalnkaziņš, motociklistu kluba „Hermejs” biedrs Guntars Lasis u.c. 2011. gadā tradīcija tika pārtraukta.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2015\/2016"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Es piedzimu Torņkalnā godīgā kaķu ģimenē, melns kā ogle, tikai pašā astes galā dažas baltas spalvas. Vecāki man deva vārdu Maurīcijs. Mans tēvs bija zvejnieks, viņam piederēja pašam\nsava laiva; no agra pavasara līdz pat vēlam rudenim viņš meta tīklus un vilka bagātus lomus –\nlašus, vēdzeles, zušus un nēģus, bet no rudens pēdējām dienām, kad upi ledū iekala lausks, līdz\npavasara pirmajām dienām kopā ar tuvējo māju kaķiem devās tālos mežos cirst kokus malkai.\nMāte, lepnā Māras dzirnavnieka meita, kopa māju, mums bija govs un kaza, savs sakņu dārzs,\nmāte šaudījās kā atspole, rūpju viņai netrūka. Ģimenē bez manis, pastarīša, bija vēl divas kaķu\nmeitenes, krietni vecākas par mani, un vecākais brālis Toms, kurš brauca uz kuģiem un mājās\niegriezās tikai ziemās.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2015\/2016"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Es, pastarītis, biju mīlēts bērns, nekā man netrūka, ne tēva gādības, ne mātes rūpju. Tikai tās māsas! To nu gan bija par daudz! It kā mājās trūktu rotaļlietu, viņas man uzģērba kleitu un iesēja astē lenti. Lai gan es brēcu tā, ka ausis plīsa pušu, māsas mani sēdināja leļļu ratos un vizināja. Kāds kauns! Reiz, glābdamies no abu māsu uzmācības, es lēcu no viena virtuves plaukta uz otru un ievēlos zupas katlā, kas burbuļoja uz pavarda! Negribu lielīties, bet jau pēc mirkļa es izlēcu no katla ar krietnu gaļas gabalu zobos. Drīz māsām radās citas intereses, viņas lika man mieru un, gredzenus ķepās samaukušas, žvadzošām kreļļu virtenēm ap kaklu, augu dienu tērgāja ar draudzenēm, mezdamas ziņkārotus skatienus uz kaķu jaunskungiem, kas turpat, Daugavmalā, sacentās tik muļķīgā nodarbībā kā tālumspļaušanā.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2015\/2016"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Pieaugot mani kā puiša cilvēku tādas muļķības neinteresēja. Tikko pagadījās kāds brīvāks brīdis, kad varēju pamukt no garlaicīgām lietām – tādas pavisam droši bija dārza ravēšana un ūdens stiepšana laistīšanai – mēs kopā ar kaimiņmāju jaunekļiem pulcējāmies Daugavmalā, paukojāmies ar koka zobeniem, sacentāmies, kurš ātrāk un augstāk uzrāpsies kokos vai tālāk aizlēks. Garlaicīgi nekad nebija, stundām ilgi mēs varējām skaļi sapņot par to, ko darīsim, kad izaugsim. Es paziņoju, ka kļūšu par jūrnieku tāpat kā mans vecākais brālis Toms un apbraukāšu visu pasauli.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2015\/2016"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Klausoties Toma stāstos, man aizrāvās elpa, acis mirdzēja. Jā, es noteikti kļūšu par jūrnieku! Velti Toms mani brīdināja, ka nav maizes bez garozas, stāstīja par smago darbu, par nedēļām, kad, kuģim iekļūstot bezvēja joslā, bija jāiztiek ar sausiņiem un bojātu gaļu, dzeramais ūdens bijis jātaupa, jo tas, aiz borta, dzeršanai nederot, esot kā tīrais sāls... Un katrs tevi, kuģapuiku, izkalpina, nē, viegls tas darbs neesot, to lai es liekot aiz auss. Es māju ar galvu, jā, jā, tie ugunsvēmēju kalni jeb vulkāni, tās tālās zemes un svešās pilsētas neizgāja no prāta.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2015\/2016"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Elvis ir 15 gadus vecs zēns. Kopā ar klasesbiedriem Justu un Agnesi viņiem jāveido prezentācija par\nkāda rakstnieka bērnības atmiņu stāstu, kas attēlots gan grāmatā, gan kinofilmā vai teātra izrādē. Elvis\nvislabprātāk lasa mūsdienu literatūru, viņu interesē pilsētas bērnu un pusaudžu dzīve gan 20.–40. gados,\ngan padomju laikos Latvijā. Agnese savukārt lasa ievērojami mazāk, un viņai ļoti patīk skatīties teātra\nizrādes. Viņu uzrunā draudzības atainojums literatūrā, bet teātrī viņu vairāk saista mūsdienīgas izrādes.\nJustu visvairāk interesē sports, un viņam patīk lasīt grāmatas par nepareizajiem pusaudžiem, kuri spurojas\npretim skolotājiem, iekārtai, sistēmai. Skolēni iepazinās ar vairākiem darbiem. ",
+  "KLASE": 9,
+  "MACIBU_GADS": "2015\/2016"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Vai gribi zināt, kā bērni Latvijā dzīvoja senāk? Par ko viņi domāja un sapņoja, kā rotaļājās, kādus darbus un nedarbus strādāja? Lasi tēlojumus „Baltajā grāmatā”! Tad kopā ar Janci varēsi izdzīvoties pa lauku sētu, mežu un pļavu. Tu uzzināsi par dzīvi agrākos laikos, iepazīsi tādas lietas, kuras mūsdienās redzamas tikai muzejā. Varēsi sastapt meža zvērus un mājas lopiņus, izjust dabas balsis, smaržas un īstu lasītprieku.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2015\/2016"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Latvijas laika Rīga nav tikai jūgendstila nami Rīgas centrā, Preses balles pie Benjamiņa kundzes vai labi paēduši un pārtikuši latvieši, kas kļuvuši par kungiem savā dzimtajā zemē. Vizmas Belševicas romāns „Bille” ir ievērojamās latviešu dzejnieces prozas darbs, un tajā ir citas Rīgas noskaņas – strādnieku dzīvoklis īres namā Grīziņkalnā, basas kājas, melna maize, trokšņaini kaimiņi, trūkums, dzelžaina nepieciešamība pēc tīrības un kārtības, bet pāri visam – sapnis par Latviju, lepnums par jauno valsti, ticība, ka savām rokām varēs izdarīt visu.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2015\/2016"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Dienasgrāmatas formā rakstītais romāns ir pirmais darbs ciklā „Smagais metāls”. Tā centrā ir 20. gadsimta 70. gadu Rīgas pusaudža pasaule, kurā atspoguļojas sabiedrības sociālie un psiholoģiskie procesi. Elitāras skolas ikdiena, draudzības un vilšanās pārejas, protests pret padomju režīmu, apbrīnojot Tarkovski, un pasaules kultūru, klātesot Baham un Šekspīram, atklāj rakstnieces G. Repšes grāmatas varones pusaudžu gadu pārdzīvojumus.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2015\/2016"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "„Mammu, es tevi mīlu” ir dinamisks attiecību trilleris par trīspadsmitgadīgu Rīgas skolnieku Raimondu un viņa māti. Kāda šķietami nenozīmīga piezīme skolā iesāk piedzīvojumiem bagātu nedēļu Raimonda dzīvē. Raimonds aizbēg no mājām, iekuļas apšaubāmā afērā, nonāk policijas redzeslokā un visbeidzot atrisina samilzušo konfliktu gan ar mammu, gan savu labāko draugu.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2015\/2016"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "„Bille” – viens no izcilākajiem 20. gadsimta 90. gadu latviešu prozas darbiem. „Bille” ir daļēji autobiogrāfisks darbs par mazo meiteni Billi, no kuras skatpunkta grāmatā atveidota pasaule. Darbība noris trīsdesmitajos gados, laikā, kas mūsdienās kārtējo reizi pārtapis zaudētajā paradīzē. Taču „Bille” nebūt nepieder salkani jūsmīgajām bērnības atmiņu grāmatām, ar kādām pārpilna latviešu literatūra. „Billē” netrūkst ne gaišuma, ne sirsnīgas ironijas, jo autorei piemīt reti sastopamā prasme arī pelēcību aprakstīt koši un iespaidīgi.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2015\/2016"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Dirty Deal Teatro izrāde skolēniem „Baltā grāmata” veidota pēc Jāņa Jaunsudrabiņa tāda paša nosaukuma darba motīviem un ir moderns stāsts par cilvēku vēlmi ticēt brīnumiem un uzdrošināšanos būt drosmīgam, lai spētu brīnumus un brīnīšanos pieredzēt. „Baltā grāmata” ir kopīgs ceļojums no mūsdienām uz 19. gadsimta laukiem. Tur ceļiniekus sagaida Jančuks, zinātkārs un aizrautīgs puika,ar kuru kopīgi atklāt un piedzīvot apkārt esošo pasauli. Lai gan ceļojums notiek rakstnieka bērnības – Jančuka pasaulē, tur pieredzētais bieži vien sasaucas ar notikumiem un sajūtām šodien. Izrāde tapusi Dirty Deal Teatro izrāžu ciklā „Līdz 18”. Tas apvieno izrādes bērniem un jauniešiem, kas tiecas uzdot jautājumus, atklāt vēl neatklāto un kļūt par kopīgu piedzīvojumu.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2015\/2016"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Jāņa Akuratera stāsts „Kalpa zēna vasara” ir rakstnieka atmiņas par vienu vasaru viņa jaunības gados. Strādājot kā kalpa zēns, Jānis pavada vasaru, veicot lauku darbus un sapņojot par laiku, kad smagie darbi būs aiz muguras. Ar šādu vīziju prātā Jānis pacieš visus nogurdinošos pienākumus, bet tikai vēlāk saprot, ka šī vasara skaistajā Latvijas dabā kopā ar jaunajiem draugiem un pirmo mīlestību patiesībā bijis viņa jaunības ziedu laiks",
+  "KLASE": 9,
+  "MACIBU_GADS": "2015\/2016"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "„Smagais metāls” ir izrāde pēc Gundegas Repšes romāna „Alvas kliedziens” motīviem. Izrādes centrā ir meitene ar pusaudzei raksturīgajiem pārdzīvojumiem. Tas ir darbs gan par draudzību, gan nodevību. Patstāvīgi domājoši pusaudži bija nevēlami padomju laikā. Šodien masu kultūra turpina manipulēt ar nenobriedušu apziņu. Galvenajā lomā: Guna Zariņa Lomās: Baiba Broka, Sandra Kļaviņa, Elita Kļaviņa, Inga Alsiņa-Lasmane, Jana Čivžele",
+  "KLASE": 9,
+  "MACIBU_GADS": "2015\/2016"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Romāna „Cilvēka bērns” autora Jāņa Klīdzēja bērnības pasaule, stāsts par Latgales Pāvulānu ģimenes dzīvi, par tradīcijām un vērtībām, kas tiek nodotas no paaudzes uz paaudzi. Galvenais varonis Bonifācijs Pāvulāns, dzīvespriecīgais un zinātkārais Boņuks, kopš agras bērnības mācās veidot attiecības ar ģimenes locekļiem un pārējiem cilvēkiem, ar Dievu un dabu. Filma ieved mūs Latgales sētā, rādot latgaļu zemnieku gudro dzīvesziņu, darbīgo ikdienu un mazās sirds auklēto pirmo mīlestību. Trimdas rakstnieka Jāņa Klīdzēja romāna ekranizācija ir īpašs veltījums ne vien bērnībai, bet arī no pārējās Latvijas kultūras savrup stāvošajai katoliskajai Latgalei. Šis izjustais slavenā režisora Jāņa Streiča darbs jau sen ieņem pelnītu vietu starp labākajām filmām, kas tapušas Latvijā.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2015\/2016"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "„Lennebergas Emīls” pārtapis filmā, kuras galvenais varonis, protams, ir Emīls. Tas pats sešgadīgais Emīls, kuru viņa tēvs ir gatavs mainīt pret zemestrīci, lai mājās būtu kāds brītiņš miera. Bet Emīls nav vainīgs – vienkārši viņš ir ļoti labsirdīgs un izpalīdzīgs, turklāt viņam vienmēr pietiek izdomas un arī enerģijas, lai labas idejas nenonīktu nerealizētas. Un vienmēr jau atrodas kāds, kam vajadzīga palīdzīga roka vai padoms… Gan māšele Ida, gan kalpone Līna, gan tēvs, māte, gan vēl kādi kaimiņi. Līna par Emīla izdarībām gaužas, ka viņas acis kaut ko tādu nav pieredzējušas, bet filmā viss risinās jautri, gaiši, ticami, un ir arī mierinājums – no Emīla izaugs krietns un sabiedrībai noderīgs cilvēks – to apsola filma „Emīla nedarbi”.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2015\/2016"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Vai iezīmējas kādas jaunas tendences valodā?\nVēstījums jau nemainās – gan nepatika pret svešvārdiem, reizēm tiešām absurdiem, gan līdzīga\nnepatika pret jaundarinājumiem, kas arī reizēm ir nebaudāmi. Aptauja ļauj saskatīt ievirzes, piemēram,\njauka ir tendence darināt tādus verbus kā „nūjot”, „ēnot”, „pūķot”, „diegot”, „raizēt”, „veikot”, „talkot”,\n„vecākot”. Tas liecina, ka latviešu valodā attīstība notiek un vārdrade ir visai dzīvīga.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2015\/2016"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Vai nevarētu būt tā, ka katra paaudze grib valodā „iezīmēt” sev teritoriju, radīt savas piederības zīmes? Radīt sev pieminekli? Nē, tas nenotiek apzināti. Protams, ir modes elementi. Mūsdienās internetā varam precīzi atrast pirmo jaunvārda vai jauna lietojuma autoru. Pirmo jaunvārdu nereti rada, lai pārsteigtu, lai būtu interesanti. Tālāk aiziet ķēdīte. Kāpēc vienos gadījumos daži jaunvārdi iesakņojas, bet citos – ne, to neviens nevar pateikt. Šī mistika, neparedzamība ir arī valodas burvība. Neviens valodnieks nevar pamatoti izskaidrot, kāpēc tas notiek. Kārtējā valodas mīkla. Dzīva valoda nav reizrēķins. Rakstu valodā gan nevajadzētu pieļaut „kad” lietošanu „ka” vietā.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2015\/2016"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Jums raksturīgs filozofisks miers pret valodas pārmaiņām, bet vai jūs tomēr kaut kas satrauc kā valodnieku, cilvēku, kurš pats lieto valodu? Kad cilvēki runā publiski, viņiem vajadzētu uz sakāmo mazliet koncentrēties. Neesmu pārliecināts, ka vairākums runātāju nav spējīgi saprātīgi izvēlēties un lietot pareizus vārdus. Tā ir nevērība, laiskums. Valoda atspoguļo vispārējas tendences, ko vieni sauc par demokratizāciju, citi – par lumpenizāciju, vēl citi – par tradicionālo normu sabrukumu. Mēs redzam, ka uz operu vasarā cilvēki iet šortos un sandalēs, kas pirms divdesmit gadiem droši vien liktos dīvaini. Tas pats notiek arī runā – redzam, maigi sakot, ļoti plašu spektru. Daudzi vairs nesaprot, kas ir publisks un kas intīms vai paviršs. Mēs nevaram teikt, ka laba latviešu valoda ir zudusi. Eleganta latviešu valoda daudzās situācijās tiek lietota.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2015\/2016"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Valodnieks Jānis Endzelīns XX gadsimta sākumā sacīja – neviens vairs nerunā pareizā latviešu valodā, tikai vecvecmāmiņas, kas nav padevušās grāmatnieku un avīžnieku iespaidam. 20. gados Kārlis Skalbe rakstīja, ka karš ir valodu neglābjami piesārņojis. Pēc Otrā pasaules kara valodnieki apgalvo, ka, lūk, 20. gados – tad nu gan latvieši labi runājuši.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2015\/2016"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Valodu veido cilvēki. Pati tā neko nerada. Vārdnīcās un valodas meistaru darbos redzam fantastiskas valodas iespējas. Lielu daļu jaunvārdu rada tulkotāji, kas, šķiet, ir galvenie mūsu valodas bagātinātāji. Es mazāk uzsvērtu daiļliteratūru, kurā tiek radīti stilistiski izteiksmīgi vārdi, bet tie valodā reti nostiprinās. Tā kā valodas likums nosaka, ka informācijai par produktiem un precēm jābūt latviešu valodā, šeit ir milzīgs lauks, kur cilvēki strādā, rāda savas spējas, gudrību vai muļķību. Varam ieiet kādā preču lielveikalā, pastaigāt gar plauktiem, kas pilni ar dažādiem knibuļiem, – tur visur būs latviešu vārdi. Kādi un vai vienmēr pareizi un veiksmīgi – tas ir cits jautājums. Vienmēr var atrast kādas lakūnas vai leksiskos caurumus. Ja ir vajadzība, tie tiek aizpildīti.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2015\/2016"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Jūsuprāt, tas ir mīts, ka vārdu krājums mūsdienu cilvēkiem ir kļuvis daudz nabadzīgāks, minot argumentu, ka cilvēki mazāk lasa? Nē, nē, mēs lasām un rakstām tik daudz kā nekad. Tikai jautājums – ko mēs lasām un ko rakstām? Domāju, ka abstrakts vidējais latvieša vārdu lietojums varētu būt mazāks, bet augšgala desmit procentos tas noteikti ir augstāks.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2015\/2016"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Paškritiski noskaņotie pārmet vārdu krājuma noplicinātību un izteiksmes izsmalcinātības iešanu zudībā. Man gan šķiet, ka Zigmunds Skujiņš raksta daudz izsmalcinātāk nekā pirms trīsdesmit gadiem. Māra Zālīte taču nav zaudējusi valodas izjūtu. Mums nekad nav bijis tik daudz specializētu žurnālu kā tagad, tik daudz izsmalcinātu oriģinālgrāmatu un tulkojumu. Protams, tie, kas dzīvo Delfu komentāru vai īsziņu pasaulē un šo valodu pārnes ikdienas saziņā, ir cita publika. Kā jau teicu, šie cilvēki agrāk reti tika pie vārda. Šī informācijas masa ir milzīga, un izsmalcinātība tajā, protams, var noslīkt. Tas ir jautājums par iekšējo filtru.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2015\/2016"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Kurš jums personīgi šķiet viens no skaistākajiem vārdiem latviešu valodā? Labs jautājums. „Laipa”. Burvīgs vārds gan pēc skaņas, gan nozīmes. Ļoti ietilpīgs vārds. Laipa, iespējams, katram asociēsies ar kaut ko citu. Var būt gan vienkāršs dēlītis, gan vesela konstrukcija, kā Ķemeru laipa, vai iekārts tiltiņš. Viens no retajiem vārdiem, kuru grūti pārcelt angļu valodā. Reiz tulkoju kādu Ziedoņa epifāniju, un tur bija teikums par nedrošo iešanu pa laipu. Tulkojot angliski, rodas jautājumi – kāpēc jāiet pa dēli vai kāpēc tilts ir nedrošs? Lūk, skaists un gruntīgs latviešu vārds.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2015\/2016"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Kukaiņi ķērās pie sagatavošanas darbiem. Zirneklis atvēra šūšanas darbnīcu, kur visiem darināja neparastus svētku tērpus. Mazās augļu mušiņas steidza gādāt traukus galda klājumam. Lakstīgala izmēģināja jaunas dziesmas. Arī graciozās spāres nenogurstoši gatavojās priekšnesumam. Kukaiņi bija laimīgi. Tikai mārīte nerosījās. Viņa gan piedalījās sanāksmē, bet ļoti kautrējās, jo nelīdzinājās pārējām mārītēm. Visiem viņas radiniekiem bija sarkanas muguriņas ar melniem punktiņiem. Tikai viņai nekā! Koši sarkano muguriņu nerotāja neviens melns punktiņš. Neviens nezināja, cik slikti viņa jutās: citas mārītes izskatījās tik skaistas!",
+  "KLASE": 3,
+  "MACIBU_GADS": "2016\/2017"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Ilgi gaidītais brīdis bija klāt! Cik skaisti svētkos dižojās kukaiņi! Tik priecīgi satraukti un lepni par sevi viņi bija! Priekšnesumi un lakstīgalas dziedājums visus aizkustināja. Slavēta tika arī gardā maltīte. Bišu karaliene apmierināti smaidīja un priecājās par izrādīto godu. Pēc balles karaliene apskatīja visas maskas, lai noteiktu veiksmīgāko. Lēmumu pieņemt nebija viegli. Izvēlēties bija ļoti, ļoti grūti! Beidzot karaliene paziņoja: „Pirmo vietu es piešķiru mārītei, kura kautrīgi paslēpusies pēdējā rindā. Viņas tērps ir neparasts! Es nekad neesmu redzējusi mārītes bez melnajiem punktiņiem. Pārsteidzoši! Nēsā vienmēr šo tērpu, jo tas tev lieliski piestāv, mārīt!”",
+  "KLASE": 3,
+  "MACIBU_GADS": "2016\/2017"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Vabolīte gan neko neteica, vien nosarka vēl vairāk. Viņa tā arī nesadūšojās pateikt, ka tas ir viņas ikdienas tērps. Beidzot viņa saprata, ka ir izpelnījusies vispārēju apbrīnu. Kopš tās dienas mārīte ir laimīga. Cik bieži mēs cenšamies līdzināties citiem, bet izrādās, ka atšķirīgums dažkārt ir vērtīgs ieguvums!",
+  "KLASE": 3,
+  "MACIBU_GADS": "2016\/2017"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Bija jauka, nedaudz tveicīga vasaras diena. Kādā meža pļaviņā kukaiņi bija nolēmuši sarīkot lielus dārza svētkus par godu bišu karalienes kronēšanai. Tika sasaukta sapulce. Tā norisinājās zem vecā riekstu koka. Vienmēr nopietnais sienāzis vadīja sapulci. Vispirms runāja augļu mušiņa, mazais dārza kukainītis: „Mēs varētu sagādāt viesiem garšīgus ēdienus un atspirdzinošus dzērienus – augļus, dārzeņus un avota ūdeni.” „Labi,” piekrita sienāzis.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2016\/2017"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Pēc tam vārdu lūdza krāšņais taurenis: „Mūzika vienmēr rada patīkamu svētku noskaņu,” viņš sacīja. „Kurš varētu mums padziedāt?” „Es!” atsaucās skanīga balss. Visi pacēla galvas un ieraudzīja lakstīgalu tuvējā zarā. „Jā, es labprāt priecēšu jūs ar skanīgām dziesmām!” teica dziedātāja. „Paldies, tu esi ļoti laipna! Mēs būsim pateicīgi!” sacīja kukaiņi. Rosīgā skudra arī piedalījās lemšanā: „Sarīkosim svētkus zem liepas. Cilvēki tur staigā reti, tāpēc mūs netraucēs.”",
+  "KLASE": 3,
+  "MACIBU_GADS": "2016\/2017"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "„Piekrītu,” sacīja sapulces vadītājs. Arī spārei bija kāda doma: „Es ar savām māsām iestudēšu baletu. Jūs taču zināt, cik gracioza es esmu!” Visi apstiprinoši pamāja. „Un tu, strādīgā slieka, vai neko neteiksi?” vaicāja sienāzis. „Es domāju,” atbildēja slieka, „ka mums jāsarīko karnevāls!” „Lieliski! Vareni!” sauca kukaiņi cits caur citu. Uz svētkiem visi nosprieda ierasties karnevāla tērpos, un bišu karaliene noteiks labāko tērpu. Uz tikšanos zem liepas!",
+  "KLASE": 3,
+  "MACIBU_GADS": "2016\/2017"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Bet kas bija noticis šeit? Uz ledus rēgojās svaigi grauztas apses skaidas un zaru gali.\nMaksis piegrūda degunu vienai vietai, piegrūda otrai un arvien vairāk pārliecinājās, ka visur\nsmaržo pēc bebriem. Tātad pavisam tuvu vajadzēja atrasties bebru alai. Nu patiesi: pēdas veda\nlīdz pašam ūdenim un tad pazuda kā nebijušas…",
+  "KLASE": 6,
+  "MACIBU_GADS": "2016\/2017"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Bet šajā krastā bebru alām bija ne tikvien ieeja zem ūdens, bet arī rezerves izejas, kuras ne katru reizi aizsedza upe, – to Maksis zināja droši un tāpēc vairākās vietās izkārpīja dziļās kupenas. Tomēr ne vecas, ne jaunas pēdas atrast neizdevās. Tāpēc pa kādas iepriekšējos palos nolīkušas vīksnas atskalotajām saknēm Maksis tika augšā stāvajā krastā. Un šeit nu gan viņa deguns teica: te ir, te ir, te noteikti ir! Bet, saņēmuši šādu precīzu deguna signālu, medību suņi, ja vien kāds tos neattur, cenšas arī piekļūt tuvāk medījumam. Un Maksis bija medību suns – medību suns savā vaļā.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2016\/2017"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Makša deguns, ieelpojot alas vilinošo aromātu, vēl vēlējās ilgāk patīksmināties. Spēcīgās priekškājas ar asajiem nagiem un ādas krokām starp pirkstiem jau ķērās pie sniega un ledus atkašāšanas. Taču te nu Maksim drīz nācās vilties – krasta krantī vecās vīksnas raupjās saknes bija savijušās tā, ka ne bebram, ne viņam pašam tur neiespraukties. Bebru smaržas vilināts, viņš, izrādījās, stāvēja pie alas vēdināmās lūkas, ko nevarēja izmantot iekšā un ārā līšanai. Tomēr tas jau netraucēja Maksim starp saknēm iebāzt purnu pēc iespējas dziļāk un visiem, kas vien vēlējās dzirdēt, paziņot: at-radu, at-radu, at-radu. Pa starpām ievelkot gaisu, Maksim pat likās, ka tur dziļi, zem vīksnas saknēm, dzird arī kādu sakustamies. Tāpēc viņš atkal pieliecās tuvāk un uzsāka no jauna: at-radu, at-radu, at-radu…",
+  "KLASE": 6,
+  "MACIBU_GADS": "2016\/2017"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Bet tad skaidri un nepārprotami zem ledus krasta tuvumā atskanēja paskaļš šļaksts, un Maksis, izvilcis purnu no alas vēdināmās atveres, vēl paspēja ar dažiem lēcieniem nokļūt no augstās krants, lai redzētu, kā no ledus apakšas iznirst viņa aprietais bebrs un pa straumi dodas uz pretējo krastu… Žigli nokūleņojis gandrīz līdz pašam ūdenim, Maksis tomēr nemetās bebram pakaļ. Lai arī lielisks peldētājs, viņš, taksītis – alu suns –, ūdenī nevarēja sacensties veiklībā ar bebru. Un to viņš labi apzinājās!",
+  "KLASE": 6,
+  "MACIBU_GADS": "2016\/2017"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Lai tiktu upes spēcīgajai straumei pāri, vajadzēja doties uz kādu no tiltiem – to nu Maksis beidzot saprata, taču vēl vairāk attālinājās no mājām. Cauri briksnājam, kur tālumā jau varēja redzēt kādas ēkas apsnigušo jumtu, veda sniegā iemīta taciņa. Maksis pa to bija norikšojis labi ja pāris simtus metru, kad pēkšņi taciņas malā pamanīja kaut ko tumšu. Palēninājis gaitu, viņš soli pa solim, ķepas nesteidzīgi cilājot, devās uz priekšu. Taciņas malā stāvošais nekustējās. Maksis savu piesardzīgo gaitu ne palēnināja, ne paātrināja. Svešais vēl joprojām stāvēja uz vietas, bet no tā puses uzvēdīja vēja pūsma, un Maksis noslēpumaino stāvētāju uzreiz pazina. Tāpēc vēl uzmanīgāk viņš gāja tuvāk – līdz abus šķīra vien dažu lēcienu attālums. Nu Maksis sastinga un saspringa lēcienam. Svešais uzmeta kūkumu, iešņācās un pacēla labo ķepu ar draudoši izlaistiem nagiem.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2016\/2017"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Tagad nu bija sastapušies divi nopietni mednieki: Maksis, alu suns un pēdu dzinējs, un neliela auguma pusmežonīga sarkanbrūna kaķene. Maksis, uzbrukuma lēcienam sastindzis, nenolaida acis no kaķenes. Un arī viņa nekustējās – ne iztaisnoja kūkumu, ne arī atslābināja pacelto ķepu. Vienīgi kaķenes dzeltenās acis brīdinoši dzalkstīja.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2016\/2017"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Un nezin cik ilgi viņi abi tā draudošās pozās stāvētu, ja pēkšņi tālumā skaļi neierietos suns. Tajā mirklī kaķene novērsās, pameta tramīgu skatu atpakaļ, un Maksis lēca uz priekšu… Kaķene, zibenīgi pavēlusies sānis, metās bēgt. Turklāt, kā jau svarā vieglāka, kaķene joņoja pa sērsnu virs sniega, bet Maksis, stigdams un atstājot aiz sevis dziļu vagu, mazliet atpalika no viņas. Tomēr tas iedzenamais gabaliņš jau nemaz nebija tik liels – tikai līdz tuvākajam bērzam, kur kaķene veikli uzskrēja pa stumbru un iešņākusies ziņkārīgi pavērās lejā.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2016\/2017"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Aizelsies Maksis arī tūlīt piesteidzās pie baltā koka un, izslējis degunu augšup, sāka lēkāt ap bērzu, skaļi ķilkstot. Var jau būt, ka viņš atcerējās gadījumu, kad šādā veidā bija izdevies kādu kaķi nobaidīt lejā un tad to kārtīgi izdzenāt, bet – visticamāk – Maksis kā medību suns pie stumbra ķilkstēja, lai paziņotu par medījumu. No lēkāšanas ap bērzu Maksis pagura, un tad, atkāpies gabaliņu nostāk, viņš uzsāka vienīgo, ko varēja šajā muļķīgajā situācijā darīt. Maksis rēja, rēja, rēja, rēja, rēja, rēja…",
+  "KLASE": 6,
+  "MACIBU_GADS": "2016\/2017"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Suņi ir bijuši cilvēkam līdzās jau kopš seniem laikiem, palīdzot apsargāt mītni, bet galvenais – palīdzot sagādāt barību. Daži no tiem bija neaizstājami palīgi, jo tiem bija laba oža. Tādus suņus sāka audzēt mērķtiecīgi, uzlabojot mednieku īpašības, un tos nosauca par dzinējsuņiem. Dzinējsuņu vidū izcēlās īpatņi – braki jeb pēdu dzinēji, kuri kļuva par ciltstēviem visiem suņiem ar nokarenām ausīm. Tādi suņi eksistēja Vācijas teritorijā 16. gadsimta vidū, tāpēc par takšu dzimteni uzskata Vāciju. Taksis tika atzīts par Vācijas nacionālo suņu šķirni, un 1880. gadā vācieši organizēja pirmo takšu izstādi.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2016\/2017"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Lielbritānijas karaliskā nama intereses dēļ takši kļuva iemīļoti suņi šajā valstī. Britiem šķita simpātiska to nestandarta āriene. Viņi deva priekšroku visam neparastajam. Ņemot vērā vēsturisko saikni starp Vāciju un Baltiju, apmēram no 17. gadsimta taksis bija populārs suns arī Baltijā. Viņus dēvēja par Kurzemes takšiem. Krievijā taksis tika ievests 18. gadsimta pirmajā pusē, kur šādus suņus turēja tikai dižciltīgajās mājās. Ārējā izskata neparastums un gudrība pievilināja bagāto cilvēku uzmanību, un takšus sāka iegādāties ne tikai medībām, bet arī kā „dāmu” sunīšus. Taksis ir ģimenes mīlulis un medību suns medībām gan virs zemes, gan alās, jo takši ir fanātiski savvaļas trušu, stirnu, mežacūku mednieki. Pēc lieluma takšus iedala trīs grupās. Vislielākais ir standarta taksis. Viņa krūšu apkārtmērs pārsniedz 35 cm, bet maksimālais svars ir 9 kg. Miniatūrā takša krūšu apkārtmērs ir 30–35 cm, bet vismazākā – kaninhena jeb trušu takša krūšu apkārtmērs nepārsniedz 30 cm.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2016\/2017"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Takša kažoks visbiežāk ir rūsgani brūns vai melns ar dzeltenbrūnu, tomēr reizēm sastopami arī takši ar šokolādes brūnu vai tīģersvītrainu kažoku. Gludspalvainā takša kažoks nav īpaši cītīgi jākopj. Pietiek, ja no tā laiku pa laikam ar gumijas ķemmi izķemmē izkritušo spalvu. Gludspalvainais taksis vārda tiešā nozīmē ne soli neatkāpjas no saimnieka – un, ja reizēm arī to izdara, tad – tikai medību instinkta vadīts. Gludspalvainais taksis ir valdonīgs. Viņš bieži grib rīkoties pats pēc sava prāta. Tāpēc viņu vajag apmācīt. Ar pareizu pieeju un milzu pacietību var panākt diezgan daudz, tomēr neceriet, ka taksis pakļausies katrai jūsu pavēlei. Ja šo suni netaisnīgi soda, viņš var pamatīgi sadusmoties. Ja viņam kaut ko neatļauj, viņš spēj būt ļoti uzstājīgs.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2016\/2017"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Tā kā taksim pirmajā vietā ir saimnieka ģimene, svešiniekiem viņam tikpat kā neatliek laika. Pret nepazīstamiem cilvēkiem viņš izturas diezgan atturīgi. Ja gludspalvainajam taksim bērnībā bijusi pozitīva saskare ar bērniem, vēlāk viņu savstarpējās attiecībās nekādi sarežģījumi nerodas. Taksis parasti diezgan labi sadzīvo ar saviem ciltsbrāļiem, tomēr reizēm pret lielākiem suņiem viņš izturas pārdroši. Tā kā taksis ir kaislīgs mednieks, viņš nav piemērots rotaļu biedrs nelieliem mājdzīvniekiem. Lai novērstu problēmas nākotnē, jau kucēna vecumā saradiniet viņu ar kaķiem! Lai uzturētu labu fizisko formu, taksim daudz jākustas. Ja viņam ļauj brīvi skraidīt apkārt bez pavadas, ir ļoti iespējams, ka medību instinkts mudinās viņu skriet prom. Gludspalvainais taksis ir vienīgais takšu sākotnējās līnijas pārstāvis, jo gan asspalvainais, gan garspalvainais taksis tika radīti, krustojot gludspalvainos takšus ar citu šķirņu suņiem.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2016\/2017"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Ar novēlējumu Stay brutal! Jāni Joņevu uzrunā kāds draugs. Viņš paskaidro: tas ir kādas metāla grupas dziesmas nosaukums, kas kļuvis par saukli. Nozīmē: paliec skarbs, bet patiess! Jānis neslēpj sevi tādu, kāds ir: pieklājīgs, uzmanīgs un interesants sarunu biedrs, it sevišķi, ja sarunu tēma saistīta ar literatūru vai mūziku. Studiju laikā Kultūras akadēmijā iemīlējis franču valodu, no franču valodas tulkojis vairākus literārus darbus.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2016\/2017"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Par ko visbiežāk domā, rakstot savus darbus? Par kādām idejām? Tas, ko mēs uzskatām par lielām idejām, bieži vien ir kompleksi, kas saistīti ar nespēju būt brīviem. Arvien biežāk runā, ka mūsdienu sabiedrībā nav vērtību, liberālisms novedis pie tā, ka nav izpratnes par labo un ļauno. No tā izriet skumjš jautājums: vai tad mēs zinām, kas ir labs un ļauns, tikai tad, kad mums to kāds stingri pasaka? Un vērtības ir tikai tad, kad mums tās uzspiež? Vai tad nemākam būt brīvi, vajag kādu, kas mūs dzenā un stāsta, kā rīkoties?",
+  "KLASE": 12,
+  "MACIBU_GADS": "2016\/2017"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Vai tu laiku pa laikam norobežojies no sabiedriskās dzīves un raksti to, ko neviens neprasa? Kāpēc tu to dari? Nevarētu teikt, ka man ir liela nepieciešamība rakstīt. Esmu gribējis rakstīt jau kopš pusaudža gadiem, tomēr tā man nav tikpat liela vajadzība kā elpot. Nesen lasīju citātu, šķiet, to teicis Malkolms Lovrijs (britu rakstnieks): „Es neesmu es, bet vējš, kas pūš man cauri.” Redzi, literātiem ir kaut kas tāds, ko viņi noķer, pamana, un tad viņiem gribas to pierakstīt. Man patīk arī Marsela Prusta (franču rakstnieka) formulējums – lai saprastu, kas ar tevi notiek, ir jāpieraksta. Taču akūtas nepieciešamības rakstīt man nav",
+  "KLASE": 12,
+  "MACIBU_GADS": "2016\/2017"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Kāpēc tomēr rakstu? Gribas izstāstīt ko tādu, ko pat draugam nestāstītu. Bernāra Marijas Koltesa (franču rakstnieka) lugā Kokvilnas lauka vientulībā teikts, ka tas, kas uz sirds, jāizstāsta tā, it kā to stāstītu vieninieka kameras sienām vai kokvilnas lauka vientulībā. Rakstot cilvēks pasaka ko tādu, ko nevienam nestāstītu, pašu svarīgāko un slēptāko. Vai, ja atklātu, tad pilnīgam svešiniekam, uz ceļa nostopēta auto šoferim. Savukārt Mišels Velbeks (franču rakstnieks) teicis, ka tad, ja dzīve mūs neapmierina, rakstot varam uzbūvēt realitāti, kurā paši esam noteicēji. Taču, kad ir šāda vara, ne vienmēr gribas veidot pasauli, kurā viss ir ideāli. Gribas, lai ir visādi.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2016\/2017"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "3. Ko tev kā literātam devis tekstu redaktora darbs? Pozitīvais devums ir izteiksmes skaidrība. Tas ir galvenais elks, kam kalpojam. Svarīga noteiktība, prasme izteikties pēc iespējas vienkāršākiem izteiksmes līdzekļiem, skaidri, nesamudžināti. 4. Kas kopš 90. gadiem, kad tev bija gari mati un tu klausījies melno metālu, ir mainījies? Unikalitātes izjūtu esmu pazaudējis. Vienlaikus zaudēju arī egoismu, kas ir labi. Negribētos, lai es būtu īpaši mainījies, jo, kad bijām jauni, bijām tīrāki, un arī vērtības bija skaidrākas nekā tagad. Toreiz labāk zinājām, kas ir labs, kas slikts. Tagad to nojaušam aizvien mazāk. Viss ir sapiņķerēts un miglaināks nekā toreiz, nav vairs savas taisnības apziņas",
+  "KLASE": 12,
+  "MACIBU_GADS": "2016\/2017"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Kas tevi, zēnu, kurš labi mācījās un auga inteliģentu ģimenē, vilka pie smagā metāla? Es neesmu unikāls gadījums. Vienu daļu metālistu veidoja tieši tādi tipi kā es, kuri bērnībā diez ko nedauzās pa pagalmiem, bet kādā brīdī saprot, ka vajadzētu. Daudzi rātnie, kuri bērnībā daudz laika pavada ar grāmatām, pusaudža gados meklē ekstrēmas izpausmes formas. Tā ir gandrīz klasika: pusaudzis, kurš sēž mājās pie grāmatām un klausās metālu. Piedienas arī nedaudz vientulības. Metālistu kultūrā vientulības izjūta ir vispārpieņemta norma, visuresoša lirika. Es uz šādu tīņu aizraušanos raugos nopietni, jo tā bieži vien ir ļoti svarīga. Tas, ko mēs izvēlamies tīņa vecumā, bieži vien nosaka, kādi būsim vēlāk. Grāmatas un mūzika man joprojām ir veiksmīgi izvēlēta eksistences forma. Vērtības, pie kurām nonācu pusaudža vecumā, man ir palikušas.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2016\/2017"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Kādas vērtības? Aisberga apakšējās daļas meklēšana. Varētu teikt, ka mana vērtība ir meklēt dziļumā, izvairoties no liekulības. Izklausās pēc manifesta saukļa. Bet būtība ir tāda: mani neinteresē lielās skatuves un spožie saloni, bet kaut kas neparasts. Mana vērtība ir iet citādu ceļu. Lai gan tā droši vien var teikt jebkurš.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2016\/2017"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "7. Tu esi izteicies, ka 90. gadi ir modē. Kā tas izpaužas? Kādu laiku šķita, ka 90. gadi ir nožēlojami, bet tagad tie ieguvuši pozitīvu patību un romantismu. Par 90. gadiem ar nostalģiju patīk runāt arī tiem, kuri paši ir dzimuši 90. gados un neko daudz no tiem laikiem neatceras. Daudziem šķiet, ka toreiz cilvēki dzīvoja skarbāk, intensīvāk, mazliet trakāk nekā tagad.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2016\/2017"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Vai tu tomēr iemācījies spēlēt ģitāru? Nē, nē! Romāns ir kā kompensācija tam, ka neiemācījos spēlēt. Klausos, kā citi spēlē. Mana muzikālā gaume paplašinājusies, klausos 19. gadsimta franču mūziku, kas ir plūstoša un melodiska, bez sarežģītiem paņēmieniem un liela traģisma. Taču vispār mūziku klausos daudz mazāk nekā pirms 20 gadiem. Smago metālu diezgan grūti klausīties, jo man iecērt apziņa, ka tas laiks ir pagājis. Taču arī no mūslaiku mūzikas mani visvairāk interesē underground. Tajā mūzikā, ko spēlē no lielās skatuves, neorientējos.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2016\/2017"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Mazo palmiņu atnesa mājās vasaras vidū un novietoja uz palodzes. Viņa labprāt lūkojās debesīs, vēroja putnus un interesantas formas mākoņus. Kad iestājās rudens, ainava aiz loga mainījās. Palmiņa ievēroja, ka pazīstamais bērzs, kas auga pretī logam, palēnām nodzeltēja. Tad rudens vēji tā lapas notrauca pavisam. Dienas kļuva arvien īsākas, uzsniga sniegs. Bērzs izskatījās tik skaists savā baltajā rotā! Kādu nakti uz loga rūts izauga milzīgs augs, līdzīgs fantastiskam ziedam. Arī tam bija lapas kā palmiņai, tikai nevis zaļas, bet balti zaigojošas. No rīta, kad palmiņa paskatījās pa logu, viņa neko vairs nevarēja saskatīt. Lielais zieds bija aizklājis visu rūti.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2017\/2018"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "„Ko tu tā brīnies?” ierunājās dīvainā puķe. „Es esmu leduskaraliene – viskrāšņākais zieds pasaulē! Palūkojies, kādas man skaistas ziedlapas! Lūk, kādas sudraba bārkstis un mežģīnes! Neviens mākslinieks nespēj uzgleznot tik burvīgu puķi, kāda esmu es!” „Tu patiešām esi neredzēti skaista,” sacīja palmiņa „Tikai es gribētu tevi palūgt atstāt kādu brīvu vietu loga rūtī, lai es varu palūkoties pasaulē.” „Kā tu iedrošinies mani apgrūtināt ar tādiem niekiem! Vai tev nepietiek, ka tu redzi mani?” Vairākas dienas un naktis leduskaraliene valdīja pār visu loga rūti. Tā mirdzēja mēnesnīcā, bet dienā laistījās kā kristāla paparde. Mazā palmiņa viņas priekšā jutās tik niecīga un nožēlojama.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2017\/2018"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Bet tad kādu rītu logā iespīdēja spilgti saules stari. Ai, kā nu vizuļoja leduskaraliene! Likās, ka tieši tagad viņa bija pašā plaukumā. Taču palmiņa, tā domādama, ļoti maldījās. Drīz vien leduspuķes lapas kļuva arvien bālākas. Jo spēcīgāk sildīja saule, jo nevarīgāka kļuva leduskaraliene, līdz beidzot no viņas uz palodzes palika pāri tikai pelēcīga ūdens peļķīte. Tik īss bija leduspuķes mūžs... Loga rūts atkal kļuva caurspīdīga, un palmiņa brīvi varēja lūkoties pagalmā. Spožās saules staros viņa pēkšņi pamanīja, ka starp divām viņas zaļajām lapām spraucas laukā vēl trešā un ceturtā. Palmiņa saprata, cik svarīgi ir dzīvot – tiekties pretī saulei un augt, augt. Nemanot bija atnācis pavasaris, un palmiņa pa logu atkal ieraudzīja daudz jauna un neparasta. Viņa bija tik laimīga!",
+  "KLASE": 3,
+  "MACIBU_GADS": "2017\/2018"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Cilvēka pēda ir kā maza ķermeņa karte ar tūkstošiem nervu galu. Masējot pēdas, uzlabojam mūsu veselību. Labākais pēdu masāžas veids ir pastaiga pa Latvijā izveidotajām baskāju takām. Tās ir speciāli iekārtotas takas, pa kurām jāstaigā basām kājām. Pirmā baskāju taka tika izveidota Ķemeru nacionālā parka teritorijā blakus Valguma ezeram. Tā saucas Valguma pasaule. Taka ir apmēram 3 km gara. Staigājot pa taku, varam sajust stikla lodīšu, koku mizu un zāģu skaidu pieskārienu. Varam pastaigāt arī pa priežu čiekuru, dažādu lielumu un formu akmeņu, grants un jūrmalas smilšu paklāju. Pievērsīsim uzmanību slidenajam balto mālu grāvim. Gan iekāpjot tajā, gan izkāpjot no tā, varam paslīdēt. Visinteresantākais uz takas ir Labo domu labirints. To var izstaigāt tikai ar lielu pacietību, mierīgu prātu un labām domām.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2017\/2018"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Otra garākā baskāju taka ir izveidota Sajūtu parkā Valmierā pie Gaujas. Šīs takas garums ir 2 km, un mūsu pēdas var izbaudīt 15 dažādus segumus. Pa taku var staigāt, izbaudot stikla lodīšu, priežu čiekuru, granīta šķembu, jūrmalas smilšu pieskārienu. Iespējams pārvarēt arī kustīgus šķēršļus. Dodoties lejup pa kāpnēm uz upi, iekāpsim sarkano mālu vannā. No tās izkāpjot, uz kājām paliks sarkanas svītras. Gaujas krastos jābūt īpaši uzmanīgiem un jāievēro brīdinājuma zīmes. Sajūtu parka takas galā drosmīgākie var nobraukt ar gaisa trosi pāri Gaujai. Pēc pastaigas pa šīm takām kājas var atpūtināt atvēsinošā ziedu vanniņā. Garākajā no takām piedāvā iedzert arī veselīgu zāļu tēju.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2017\/2018"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Tajā brīdī, kad 6 gadu vecumā „satiku” „Gredzenu pavēlnieku”, es sapratu, ka gribu rakstīt, turklāt gribu rakstīt fantāzijas literatūru. Mani fascinēja un joprojām fascinē iespēja izkāpt ārpus ikdienas robežām, pastiept realitāti garumā un plašumā, pat mazliet to saplēst, lai paskatītos, kas notiek aiz priekškara. Ļaujot iztēlei brīvu vaļu, es varu aizceļot uz citām pasaulēm, izdzīvot tūkstošiem dzīvju, paņemt atvaļinājumu no realitātes – kaut vai uz pāris stundām. Kas var būt vēl labāks?",
+  "KLASE": 6,
+  "MACIBU_GADS": "2017\/2018"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Sākumā es rakstu pati sev – to, ko man pašai gribētos lasīt. Tas ir labs dzinulis – ja man gribas zināt, kas notiks tālāk, atliek vien ņemt kladi un pildspalvu un to noskaidrot. Ja runājam par plašāku lasītāju loku, tad rakstu fantāzijas cienītājiem – gan tiem, kuriem šī ir pirmā tikšanās ar šo žanru, gan arī tiem, kuri to jau labi pazīst. Uz vecuma grupām gan nekoncentrējos – lai gan liela daļa manu lasītāju ir jaunieši, „Pūķa dziesma” esot iecienīta arī senioru vidū.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2017\/2018"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Es pati visvairāk lasu fantāzijas žanra literatūru. Tā ir gan lieliska iespēja atpūsties no ikdienas, gan noskaidrot, kas šajā žanrā jau ir izdarīts. Pašlaik lasu Džima Bučera (Jim Butcher) sēriju „Dresden Files” un izbaudu veiklību un asprātību, ar kādu labs autors risina sižetu, kura centrā ir privātdetektīvs burvis.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2017\/2018"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Cenšos iespēju robežās izlasīt visu, ko latviešu autori ir sarakstījuši fantāzijas un fantastikas žanrā. Pēdējā laikā gan tas kļūst arvien grūtāk, jo šādu darbu ir krietni vairāk nekā pirms pāris gadiem, – un tas mani iepriecina! No mūsu fantastiem man ļoti patīk Lindas Nemieras grāmatas – tajās ir atrodams asprātīgs sižets un dzirkstošs humors, kas vienmēr uzlabo dienu. Laiku pa laikam atgriežos arī pie klasiskām vērtībām un visbiežāk pārcilāju Rūdolfa Blaumaņa darbus, jo, lai gan tie ir rakstīti pirms krietna laika, no tiem var ļoti daudz mācīties gan sižeta vērpšanas, gan kodolīguma ziņā.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2017\/2018"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Katru dienu cenšos atrast kaut vai pavisam mazu iemeslu priekam. Tas var būt rīts, kad esmu piecēlusies agrāk un paspējusi izdarīt vairāk nekā citkārt. Pastaiga pa klusām piepilsētas ielām vakarā. Tikšanās ar draugiem un tik aizrautīgas sarunas un smiekli, ka kafejnīcas personāls mums lūdz uzvesties klusāk. Skaļš rokkoncerts, kluss vakars ar labu grāmatu, klēpī murrājošs kaķis, pieclapīte ceriņos – jebkas. Un, kad saproti, ka priekiem nav obligāti jābūt lieliem, tad ir daudz vieglāk tos pamanīt.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2017\/2018"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Es gribu izstāstīt stāstu. Gribu, lai, to lasot, cilvēki labi pavadītu laiku un pēc pēdējās lappuses izlasīšanas varētu teikt: „Šī bija patiešām laba grāmata.” Tas arī viss",
+  "KLASE": 6,
+  "MACIBU_GADS": "2017\/2018"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Latvijas Nacionālās bibliotēkas vēsture ir gandrīz gadsimta garumā. Bibliotēka tika dibināta 1919. gada 29. augustā. Pirmā ēka atradās Daugavas labajā krastā Vecrīgā – Jaunielā 26. Savukārt Latvijas Nacionālās bibliotēkas jauno ēku 1989. gadā projektēja pasaulē atzītais latviešu izcelsmes arhitekts Gunārs Birkerts. Iepretim Vecrīgai Daugavas kreisajā krastā 2014. gada 29. augustā, vienlaikus atzīmējot bibliotēkas 95. gadskārtu, atklāja jauno Latvijas Nacionālās bibliotēkas ēku jeb Gaismas pili.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2017\/2018"
+ },
+ {
+  "TEKSTA_FRAGMENTS": ". Pašlaik bibliotēkā strādā ap 400 darbinieku un dienā ir iespējams apkalpot 3000 lasītāju. Viņu ērtībām ir iekārtotas tūkstoš lasītāju vietas. Bibliotēkas krājumā ir vairāk nekā 4 miljoni vienību. Ikvienam ir iespēja dāvināt Latvijas Nacionālajai bibliotēkai sev nozīmīgu grāmatu, titullapā ierakstot vēlējumu vai personisku stāstu, kas saistās ar šo grāmatu. Tā kopā ar citām tiks glabāta Gaismas pils Tautas grāmatu plauktā, kas sniedzas piecu stāvu augstumā.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2017\/2018"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Interesenti gida pavadībā var doties ekskursijā pa bibliotēku no pirmā stāva līdz divpadsmitajam. Ekskursanti uzzina par lasītavām un bibliotēkas piedāvātajiem pakalpojumiem, apskata Rīgas panorāmu no augšas. Ekskursijas tiek organizētas latviešu, krievu, angļu un vācu valodā.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2017\/2018"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Lai kļūtu par Latvijas Nacionālās bibliotēkas lasītāju, nepieciešams reģistrēties bibliotēkā. Latvijas Nacionālās bibliotēkas lasītāja karti reģistratūrā var saņemt no 15 gadu vecuma. Savukārt, ja lasītājs ir 5 līdz 14 gadus vecs, viņam izsniedz Latvijas Nacionālās bibliotēkas bērnu lasītāja karti. Ja reģistrējas nepilngadīga persona līdz 18 gadu vecumam, nepieciešama vecāku klātbūtne vai rakstiska atļauja. Dodoties uz bibliotēku, līdzi jāņem pase vai ID karte. Fotogrāfija līdzi nav nepieciešama, to izveido uz vietas reģistratūrā. Lasītāja kartes izgatavošana ir bezmaksas. Ja lasītāja karte ir pazaudēta, reģistratūrā lasītājam izgatavo jaunu karti, par ko jāmaksā trīs eiro.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2017\/2018"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Bibliotēku drīkst apmeklēt, arī nereģistrējoties par lasītāju. Tādā gadījumā reģistratūrā tiks izsniegta apmeklētāja caurlaide, kas dos iespēju apskatīt bibliotēku kā individuālajam ekskursantam. Tomēr jāņem vērā, ka apmeklētāja caurlaide liedz izmantot bibliotēkas sniegtos pakalpojumus. Lasītājam jāievēro noteikumi. Jārēķinās, ka grāmatas un citus materiālus izsniedz izmantošanai tikai uz vietas lasītavās, uz mājām tos līdzi ņemt nedrīkst. Lasītavās ir atļauts ienest personīgās grāmatas un dažādus iespieddarbus, portatīvos datorus un nepieciešamās tehniskās ierīces",
+  "KLASE": 6,
+  "MACIBU_GADS": "2017\/2018"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "s. Par atļauju ienest lasītavās citas personīgās mantas, to skaitā ēdienu un dzērienu, jājautā bibliotēkas darbiniekiem. Bet visu izmēru somas ir jāatstāj garderobē vai mantu glabātuvē slēgtajā skapītī, atstājot slēdzenē viena eiro monētu, kas tiek atdota pēc skapīša izmantošanas beigām. Latvijas Nacionālajā bibliotēkā apmeklētājiem pieejamas dažādas lasītavas. Tā 3. stāvā atrodas Periodikas lasītava, kuras krājumu veido Latvijā un citviet pasaulē izdotie laikraksti un žurnāli latviešu valodā, kā arī Latvijā citās valodās publicētie laikraksti un žurnāli. Materiāli saglabājušies no 18. gadsimta līdz mūsdienām.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2017\/2018"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Audiovizuālā lasītava iekārtota 4. stāvā. Tās krājumā glabājas skaņu un video ieraksti, filmas, multimediju izdevumi, valodas mācību līdzekļu komplekti, aptverot periodu no 20. gadsimta sākuma līdz mūsdienām. Kolekcijā ietilpst klasiskās un populārās mūzikas un teātra mākslas ieskaņojumi, dabas skaņu un tehnisko trokšņu ieraksti. Pieejami arī operu, baletu un koncertu videoieraksti, kā arī dažādu žanru un tematikas filmas.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2017\/2018"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "6. stāvā ierīkota Sīkiespieddarbu lasītava. Tās krājumu veido vairāk nekā 1 miljons sīko iespieddarbu, proti, telefonu un adrešu grāmatas, afišas, etiķetes, kalendāri, teātra, kino un sporta programmas, instrukcijas, reklāmas lapas. Tie atspoguļo dzīvi Latvijā no 19. gadsimta sākuma līdz mūsdienām",
+  "KLASE": 6,
+  "MACIBU_GADS": "2017\/2018"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "6. stāvā atrodas arī Karšu un ģeotelpiskās informācijas lasītava. Tā piedāvā informāciju par Latviju un citām pasaules valstīm. Apmeklētāji var aplūkot kartes, pilsētu plānus, atlantus, globusus, tūrisma ceļvežus. Krājumā ietilpst materiāli, sākot no 18. gadsimta līdz mūsdienām. Uz tikšanos Latvijas Nacionālajā bibliotēkā!",
+  "KLASE": 6,
+  "MACIBU_GADS": "2017\/2018"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Matīss Kaža ir 21 gadu vecs jaunietis, kurš apgūst kino režiju Ņujorkas Universitātes Tiša Mākslas skolā. Viņš dzimis 1995. gadā Zviedrijā, Stokholmā, bet audzis un mācījies Rīgā. Jaunais režisors stāsta, ka nāk no kino vides – viņa mamma ir režisore Una Celma, bet vectēvs bija režisors Rīgas Kinostudijā, savukārt Matīsa tēvs ir žurnālists Juris Kaža. 2017. gadā pirmizrādi piedzīvoja pirmā, bet, cerams, ne pēdējā Matīsa Kažas, latviešu režisora, pilnmetrāžas dokumentālā filma „Vienu biļeti, lūdzu!”.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2017\/2018"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Galveno varoni es atradu Ņujorkas teātrī. Pirmā izrāde, uz kuru aizgāju Ņujorkā, bija „Tēvocis Vaņa”. Piecas minūtes pirms izrādes sākuma zālē ienāca Nikija ar diviem maisiem un apsēdās man tieši blakus. Pēc izrādes pirmā cēliena viņa sāka uzdot dažādus jautājumus – kāpēc esmu ieradies, ko gribu ieraudzīt, kāpēc vispār eju uz teātri.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2017\/2018"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Sarunas noslēgumā viņa piedāvāja aiziet uz vēl kādu izrādi kopā. Nikija saprata, ka es interesējos par teātri. Mēs sadraudzējāmies, ja tā var teikt. Tajā sezonā kopā noskatījāmies kādas 50 izrādes. Šajā laikā sapratu, ka viņai ir visādi triki, kā dabūt brīvbiļetes. Nikija uzskata, ka viņai pienāktos skatīties teātri par velti, ņemot vērā, ka fano par teātri.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2017\/2018"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Tomēr viņa bija diezgan noslēgta – par sevi negribēja runāt, bet man uzdeva dažādus jautājumus. Runājām par filozofiskām vai teātra tēmām. Bet es kaut kā viņu atkodu, un pamazām Nikija atklāja savu dzīvesstāstu un teātra kaislību. Sapratu, ka tas ir dokumentāls stāsts, kurš jāfilmē, jo šī sieviete ir ļoti kinematogrāfiska.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2017\/2018"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Mani, protams, vairāk interesē spēlfilmu veidošana, bet dokumentālais kino ir citāds. Arī ļoti interesants. To veidojot, var iepazīt īstus cilvēkus un sekot viņiem reālās situācijās, kaut gan, tiklīdz parādās kamera, nekas vairs nav gluži kā dzīvē. Nikija ir tik kinematogrāfiska varone, ka grēks viņas stāstu pasaulei nepastāstīt.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2017\/2018"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Nē, nav. Arī šī filma nav tikai dokumentāla, un es to neslēpju. Droši vien daži režisori to slēptu. Protams, daudz kas tika izdomāts iepriekš, protams, ka tur ir ainas, kurās kaut kas iestudēts. 4. Vai, tavuprāt, kino tendences mainīsies? Pēdējo gadu laikā esam iepazīstināti ar virtuālo realitāti. Tas ir tāds pats lēciens kā tad, kad parādījās skaņu kino – pilnīgi cits uztveres veids, pilnīgi cita valoda. Montāža vairs nestrādā kā tradicionālajā filmā. Kā mēs šo metodi apgūsim un kā izmantosim, ir atkarīgs no mums pašiem – vai tā tiks izmantota tikai videospēļu radīšanai vai tomēr arī kino.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2017\/2018"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Daudzi uztraucas par to, ka kino pamazām pārņems roboti un mākslīgais intelekts sāks montēt filmas un spēs analizēt to, kā ir veidotas, piemēram, 50 labākās filmas, un tad reproducēt šo montēšanas algoritmu topošajās filmās. Būs izdevīgāk filmu ielikt pašmontējošā programmā, nevis algot montāžas režisoru. Ir filmas, kas uzņemtas pēc mākslīgā intelekta rakstītiem scenārijiem – tas ir izanalizējis tūkstošiem scenāriju un uzrakstījis ko jaunu. Tas ir diezgan satraucoši, jaunā tehnoloģija ir reizē gan drauds, gan iespēja. Protams, virtuālā realitāte ir fascinējoša, un ir interesanti vērot, kā šis jaunais formāts mainīs industriju un varbūt radīs arī ko jaunu.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2017\/2018"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Manuprāt, ir trīs faktori. Pirmajā vietā ir pieprasījums – mūsdienu skatītāju ļoti interesē filmas par supervaroņiem. Otrajā – pasaules politiskie notikumi. Piemēram, pēc notikumiem Fērgusonā strauji uzplaukst Amerikas afroamerikāņu neatkarīgais kino. Kā zināms, Oskaru par labāko filmu 2017. gadā ieguva „Mēnessgaisma” („Moonlight”).",
+  "KLASE": 12,
+  "MACIBU_GADS": "2017\/2018"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Dokumentālajā kino tiek aktualizētas tēmas, kas ir politiski un sociāli nozīmīgas un atklāj nesenus vēsturiskus notikumus. Spēles kino, protams, mazākā mērā. Trešais, kas diktē saturu, ir eksistējoša materiāla popularitāte. Ja kāda grāmata ir ļoti populāra, tad ir garantija, ka tā tiks pārvērsta kino, pat ja nav īsti ekranizējama. Tātad jau esošie materiāli – ļoti populāri komiksi, multfilmas, lugas – noteikti nonāks uz ekrāna, jo popkultūrā viss slavenais tiek pārvērsts kinofilmā.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2017\/2018"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Pietrūkst oriģinalitātes. Ņemot vērā tos apstākļus, kurus es tikko izskaidroju, mūsdienu kino ir ļoti lielā mērā balstīts uz jau eksistējošiem materiāliem. Piemēram, septītā filma par Dzelzs vīru vai Betmenu, trešā filma par grāmatu „Bada spēles” un tā tālāk. Tas viss aiziet tādā jau esošā materiāla reproducēšanā. Ļoti pietrūkst spēcīga, oriģināla kino darba – it īpaši komerckino.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2017\/2018"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Vai vari nosaukt pagājušā gadā iznākušu oriģinālfilmu, kuras sižets nav ņemts no komiksa grāmatas, mūzikla vai kā cita? Es varu nosaukt vienu – „La La Land: Kalifornijas sapņi”, kaut gan arī tai pamatā viena īsfilma. Vairāk neko oriģinālu uzreiz nevaru nosaukt.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2017\/2018"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Visur, kur var filmēt! Kino ir māksla, kurā nepastāv ģeogrāfiskās robežas. Par Latviju būtu racionāli domāt tāpēc, ka esmu šeit audzis. Kultūrkonteksts man ir labi saprotams, te var atrast stāstus, kas man varētu būt ļoti personīgi. Mani īpaši interesē vesterns, detektīvs, zinātniskā fantastika, un šie žanri ir universāli jebkur. Ar beduīniem tuksnesī var taisīt detektīvu.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2017\/2018"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Kino nav valodas barjeras, jo pastāv subtitri, turklāt ar stāstiem un cilvēkiem ir viegli asociēties. Cilvēka psiholoģija ir interesanta ar to, ka mēs varam izjust empātiju pret varoņiem neatkarīgi no viņu rases, etniskās piederības vai dzimuma. Tas gan notiek tikai tad, ja stāsts ir veiksmīgi parādīts un režisors nav, kā Nikija teiktu, filmā projicējis savu ego.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2017\/2018"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "„Jubilejas ir labs iemesls, lai sarosītos un izdotu kādu pamatīgu pētījumu par mākslinieku un rakstnieku Albertu Kronenbergu,” tā sarunā Kultūras Rondo atzīst Alberta Kronenberga mazmeita Ilze Jansone-Saulīte. Apgāds „Neputns” izdevis somu rakstnieka un žurnālista Jukas Rislaki grāmatu „Vilki, velni un vīri. Alberta Kronenberga dzīve un daiļrade”, kuru no somu valodas tulkojusi Anna Žīgure.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2018\/2019"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "„Kāpēc soms raksta par latviešu autoru? Es bieži arī sev to jautāju. Un mana atbilde bija – kāpēc ne!” tā par savu apjomīgo darbu „Vilki, velni un vīri. Alberta Kronenberga dzīve un daiļrade”, kas tapis desmit gadus, sarunā Kultūras Rondo saka somu rakstnieks un žurnālists Juka Rislaki.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2018\/2019"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Patiešām – kāpēc ne? Somu žurnālists un rakstnieks Juka Rislaki, dzīvodams Latvijā, ir brīnišķīgi iemācījies latviešu valodu. Grāmatu par Kronenbergu gan viņš rakstījis somu valodā, to latviski tulkojusi viņa sieva, tulkotāja Anna Žīgure.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2018\/2019"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Pamudinājums ķerties pie darba par Albertu Kronenbergu viņam bijusi iepazīšanās ar mākslinieka meitu Rutu Kronenbergu. „Viena mana karikatūra bija veltīta Kronenbergam, viņa piezvanīja un prasīja, kāpēc. Tā sākām sarunāties,” atklāj Rislaki, kuram pirmā tikšanās ar Albertu Kronenbergu bijusi, lasot darbu „Mazais ganiņš”, taču visvairāk patikusi grāmata „Sprunguļmuižā gadatirgus”.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2018\/2019"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "„Liekas, ka Juka ir labi un dziļi izpratis un dziļi izpētījis materiālu, par ko raksta. Tas viņam asinīs. Pirms ķeras pie rakstīšanas, viņš cītīgi veic izpētes darbu, mēģina atrast visu, ko var,” stāsta Anna Žīgure.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2018\/2019"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "„Tulkot nebija pārāk sarežģīti. Pievienotā vērtība, ka dzīvojam vienā mājā un mūsu darba istabas ir blakus,” stāsta Anna Žīgure. „Ja ir kaut kas, ko nesaprotu vai esmu pārpratusi, vīram pavaicāju. Kad esmu iztulkojusi, Juka lasa un veic labojumus.”",
+  "KLASE": 9,
+  "MACIBU_GADS": "2018\/2019"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "„Šī grāmata ir kaut kas īpašs, ilgus gadus būvēts grandiozs panākums. Ja tā nebūtu sākusi tapt un veidoties, ģimene nebūtu sasparojusies uz radu apzināšanu, dzimtas koka pētīšanu, nebūtu jaunākajai paaudzei stāstījusi par vecvecvectēvu,” ar gandarījumu atzīst Alberta Kronenberga mazmeita Ilze Saulīte-Jansone.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2018\/2019"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Viņa arī atklāj, ka Leļļu teātris ir ieinteresējies par darba „Tuntuļu Jurītis” iestudēšanu, vēl Alberta Kronenberga 130. jubilejas gadā ir doma izdot darbu „Mazais ganiņš”, bet uz Ziemassvētkiem taps marku komplekts ar A. Kronenberga darbu varoņiem sadarbībā ar Latvijas pastu.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2018\/2019"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Starp citu, grāmatas atvēršanas svētki notika Raiņa un Aspazijas vasarnīcā Majoros, un tā nav nejaušība, jo Alberts Kronenbergs ar Raini ir ticies, Rainim paticis Kronenberga iekoptais dārzs, un Rainis kādā ciemošanās reizē uzdāvinājis Kronenbergam rozi.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2018\/2019"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Alberts Kronenbergs ir jūrmalnieks – dzimis Slokā, visus darbus sarakstījis Majoros. Jūrmalā ir viņa vārdā nosaukta iela, kā arī Slokas bibliotēka. Ilze Saulīte-Jansone atklāj, ka viņai ir sapnis par Alberta Kronenberga parka izveidi Jūrmalā.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2018\/2019"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "„Bērnībā bija privilēģija lasīt žurnālu „Mazās Jaunības Tekas”. Ik pa brīdim mamma pateica – tas ir vectēva darbiņš. Tā es sapratu, ka viņš ir mākslinieks,” atminas Ilze Saulīte-Jansone. „Ģimenē nebija tā, ka sludinātu, ka viņš ir vienīgais, lielākais, labākais. Viņa darbi ir ienākuši ģimenes leksikā. Arī man mīļākais darbs ir „Sprunguļmuižā gadatirgus”, un tāds termins kā „kurmja ūdens” ģimenē tiek lietots reizēs, kad ir runa par atklātu melošanu.”",
+  "KLASE": 9,
+  "MACIBU_GADS": "2018\/2019"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Juka Rislaki atklāj interesantas paralēles somu un latviešu literatūrā, arī Tūvei Jansonei ir kāds stāsts par tirgu, kur dzīvnieks vai trollis pārdod viltotu apvārdotu ūdeni. Alberts Kronenbergs ir iedvesmojis daudzus – gan Raimondu Paulu ar „Dzeguzīti”, gan Jāni Paukštello, lai radītu dziesmu spēli „Mazais ganiņš”, gan Pēteri Liepiņu un Imantu Zemzari, lai atkal un atkal Dailes teātrī spēlētu „Jērādiņu”.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2018\/2019"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Jukas Rislaki grāmata „Vilki, velni un vīri” veltīta mākslinieka, grāmatu ilustratora un autora Alberta Kronenberga (1887–1958) dzīvei un daiļradei. Ar A. Kronenberga radītajiem tēliem – Tuntuļu Jurīti, Jērādiņu, mazo ganiņu – izaugusi ne viena vien paaudze. Grāmata būs patīkama atkalredzēšanās vai iepazīšanās ar humora pilno mākslinieku un grāmatu autoru.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2018\/2019"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "„Pārcēlies uz dzīvi Latvijā, sāku mācīties latviešu valodu – arī no grāmatām, ko ilustrējis mākslinieks Alberts Kronenbergs. Viņa zīmējumi tūlīt pievērsa manu uzmanību. Soma acij tie ir tīkami, un manī modās neizskaidrojama māju izjūta. To labi varēja atpazīt, bet var teikt arī, ka šie zīmējumi ir ļoti latviski. Intuitīvi jutu, ka A. Kronenbergs ir kaut kas tikpat latvisks kā speķa pīrāgi, Jāņu siers, K. Skalbes dzeja un R. Blaumaņa lugas, dziesmu un deju svētki un arī dainas.”",
+  "KLASE": 9,
+  "MACIBU_GADS": "2018\/2019"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Alberts Kronenbergs bija daudzpusīga un radoša personība, mūsdienās viņu galvenokārt pazīst kā bērnu grāmatu autoru. A. Kronenbergs mācījies Venjamina Blūma Rīgas zīmēšanas un gleznošanas skolā, Jaņa Rozentāla studijā un Pēterburgas Ķeizariskajā mākslas veicināšanas skolā. Mākslinieka radošā darbība aizsākās gadsimta otrās desmitgades pirmajā pusē, kad iznāca pasaku grāmata „Brīnumu stabulīte” ar viņa zīmētām krāsainām ilustrācijām; viņš pirmo reizi piedalījās izstādē, un sākās cieša sadarbība ar mēnešrakstu „Jaunības Tekas”.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2018\/2019"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "1931. gadā klajā nāca pirmā A. Kronenberga ilustrētā un sarakstītā bērnu grāmata „Mazais ganiņš un viņa brīnišķīgais ceļojums”. Tā guva lielus panākumus, un nākamajos gados jau tapa grāmatas „Zelta laiki” (1932), „Tuntuļu Jurītis” (1935), „Jērādiņa” (1937), „Sprunguļmuižā gadatirgus” (1938). Mūža laikā A. Kronenbergs ilustrējis apmēram 130 grāmatu un vairākām sacerējis arī tekstu. A. Kronenbergu dēvē arī par latviešu komiksa žanra pamatlicēju. Mākslinieks stāvējis pie latviešu politiskās karikatūras šūpuļa. „A. Kronenberga grāmatas nebūt nav elēģija kādai pagājušai, nogrimušai bērnu pasaulei, bet drīzāk kaut kas līdzīgs konkrētai utopijai, kādai bērnībai, kurā ir skaisti un labi būt bērnam.” (Margita Gūtmane)",
+  "KLASE": 9,
+  "MACIBU_GADS": "2018\/2019"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Ir cilvēki, ar kuriem vari neredzēties mēnesi, gadu vai desmit, bet satiekoties turpināt teikumu, kas visu šo laiku klusi ir gaidījis savu brīdi. Cilvēki, no kuriem arvien esi domas attālumā. Viens no tādiem ir ALBERTS BELS. Tad kāpēc gan es tik neprātīgi satraucos, it kā pieļautu domu, ka viņš varētu atteikt sarunu. Viņš neatteica.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2018\/2019"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Kad diktofons pierakstīts pilns un iemests somā, pēkšņi attopos, ka jau atkal neesmu pajautājusi: kāpēc Cīrulis pārtapa tieši par Belu? Un te nu Alberts atkal smej: viss ir vienkārši! Mirdza Ķempe uz zīmītes pie viņa manuskripta savulaik uzrakstījusi: baigi ellīgs latviešu stāstnieks. Bels. Tāpēc šī mūsu intervija būs nevis dialogs, bet stāsts. Baigi ellīgs. Latvieša stāsts.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2018\/2019"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Ne bērnībā, ne skolas gados par rakstīšanu es nedomāju. Mums mājās – kā tolaik visās latviešu lauku mājās – bija liela bibliotēka, kur bija savākti gan mūsu rakstnieku, gan arī Eiropas rakstnieku kopoti raksti. Tur bija lielie krievu rakstnieki, lielie vācu rakstnieki, kā arī lielais norvēģis Knuts Hamsuns, lielais polis Henriks Senkevičs, kas uz mani atstāja milzīgu iespaidu. Ir divas grāmatas, kas mani ietekmējušas visspēcīgāk, – viena ir Bībele, otra – Latvju dainas.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2018\/2019"
+ },
+ {
+  "TEKSTA_FRAGMENTS": ". Es domāju, ka dainas noteikti jāmāca skolā, ne tā, ka jāiezubrī atsevišķas četrrindes, bet lielajā tvērienā: kas ir dainu filozofija, kādu spēku mēs no šā avota varam dabūt. Cilvēkam, kas dzīvo dainu kultūrā, ir pavisam cita attieksme pret lielajām lietām – tādām kā nāve, mīlestība, tēvu zeme. Taču tolaik man pat sapņos nerādījās, ka es arī pats varētu rakstīt.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2018\/2019"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Par rakstniecību sāku domāt pēc tam, kad biju neveiksmīgi startējis uz režisoriem kino institūtā Maskavā. Bet man gribējās paust savu attieksmi pret pasauli, pret dzīvi. Un tad notika tā, ka es nokļuvu slimnīcā. Tur nebija ko darīt, taču tur bija bibliotēka, kur es atradu Konstantīna Paustovska „Zelta rozi”, grāmatu, kas skar literārās darbības principus. Es to izlasīju un nolēmu, ka man arī jāraksta.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2018\/2019"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Mīlestības impulss, ko saņēmu no savas sievas, palīdzēja iesākt pirmo romānu. Es varbūt romānistikai vispār nebūtu pievērsies, rakstīju īsos stāstus, ārkārtīgi veiksmīgi rakstīju, biju apguvis tehniku un apjomu. Par īso stāstu tolaik maksāja pieklājīgu honorāru. Rakstīt romānu man nebija nolūka. Pat īsti nezināju, kas tas ir un kā to būvēt. Bet kopā ar sievu sāku klausīties simfonisko mūziku. Un tad reiz, klausoties Sergeja Rahmaņinova Otro klavierkoncertu, es sāku saprast kompozīciju. Kā tas ir uzbūvēts, kā sajūgts kopā, kā attīstās visas līnijas un kā katrs mūzikas solis rada to lielo iespaidu. Tā dzima ideja rakstīt „Izmeklētāju”.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2018\/2019"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Pirms tam es daudz domāju par romānu, sapratu, ka lielie romāni, kā, piemēram, Džeimsa Džoisa „Uliss”, prasa milzīgu lasītāja piepūli. Es gribēju rakstīt formātā, ko var izlasīt vienā nedēļā, vēl labāk – divos vakaros, bet, ja ļoti grib, tad astoņās stundās. Es izstrādāju savu mazā romāna struktūru un uzrakstīju „Izmeklētāju”, kas izrādījās tīri veiksmīgs.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2018\/2019"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Un pēc tam bija „Bezmiegs”, neveiksmīgs.\nLikteņa ziņā. Man vienkārši tika pateikts acīs, lai es to noliekot klusā plauktā un lai neiedrošinoties lasīt\nsabiedriskās vietās, pretējā gadījumā būšot smagas sekas man un manai ģimenei. Bet tajā visā bija\nkas negaidīts. Ja kaut kas tāds notiek, rakstniekā rodas aizturēts spēks. Tāds spēks radās arī manī.\nMan tas izpaudās „Būrī”. Ja nebūtu noklusēts „Bezmiegs”, diez vai es „Būri” būtu uzrakstījis. Bet būra\nsituāciju radīja toreizējā attieksme pret brīvo vārdu.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2018\/2019"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Romānu rakstot, vajag dabūt sevī darba ritmu. Jāstrādā noteiktā laikā. Taču nedrīkst arī pārvilkt pāri strīpai, kas dienas darbu ietver. Stāstu var uzrakstīt vienā dienā, vienā elpā – visu līdz galam. Bet, romānu rakstot, tā nedrīkst darīt. Ja pārrauj pāri, nav labi. Pat ja esi iegājis labā ritmā un viss raiti iet un risinās, noteiktā laikā ir jāapstājas. Jānoliek malā un tad nākamajā dienā jāatgriežas. Lielākais joks jau ir tas, ka naktī zemapziņa strādā un romānu būvē tevī iekšā.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2018\/2019"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Agrāk rakstīju ar rakstāmmašīnu, tagad – ar datoru. Datoram ir viena slikta īpašība – viss pārāk viegli nāk. Mašīna prasa lielāku organizētību. Jāpārdomā precīzāk, stingrāk jāpieslēdzas frāzei, teikumam, vārdu kārtībai. Agrāk bija tā: ar mašīnu uzrakstu melnrakstu un tad ar zīmuli vai lodīteni eju cauri – tas ir pats interesantākais. Pēc tam pārrakstu tīrajā, un pēc tam vēl vienu reizi.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2018\/2019"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Mana formula ir vienkārša – kritika ir jāuzklausa, bet tai nav jāklausa. Tas arī viss. Vairāk neko nevaru teikt. Vispār jau kausam, ko kalējs izkaļ, nospodrinājumu parasti dod kritika. Tā pasaka, kas tur stiprs, uz ko varētu balstīties lasītājs. Ir arī kritiķi, kuri akcentē slikto. Bet, pasarg dies, lai es sāktu kritiķus mācīt! Tā tik vēl trūka! Tie ir gudri, izglītoti cilvēki, kāpēc man būtu jābojā viņiem dzīve ar saviem padomiem?",
+  "KLASE": 12,
+  "MACIBU_GADS": "2018\/2019"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Atzinība katram cilvēkam ir svarīga. Tā uzlabo garastāvokli vismaz uz vienu dienu. Rakstniekam atzinība ir īpaši vajadzīga. Rakstnieks būtībā ir kā istabas augs – darbs, sevišķi prozā, liek ilgu laiku atrasties telpā, zināmā sastinguma stāvoklī. Tāpēc rakstniekam kā istabas augam ir svarīgi, ka viņu aplej ar atzinības skaidro ūdentiņu, lai viņš nenokalst. Tev ir jābūt redzamam, lai tas, ko tu saki, kļūtu dzirdams.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2018\/2019"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Lielā tīrumā auga cukurbiete Sana. Tā bija salda, bet izskatījās pelēcīga un nepievilcīga. Otrā ceļa pusē dārzā aiz neliela žoga saulē rotājās lieli, dzelteni ķirbji, sarkani, spīdīgi tomāti, zaļie zirnīši un raibās pupiņas, koši oranžas krāsas burkāni. Pat Sanai radniecīgā galda biete varēja lepoties ar savu skaisto krāsu, apaļīgo un labi veidoto figūru. Sana jutās ļoti bēdīgi.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2019\/2020"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Aiz tīruma bija augļu dārzs. Pavasarī cukurbiete Sana ļoti labi varēja saskatīt kuplās un zarainās ābeles, bumbieres, skaisti ziedošos plūmju un ķiršu kokus. Jau vasaras sākumā viņa vēroja, kā mazie, zaļie augļi aug, kļūst krāsaini un pamazām nogatavojas.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2019\/2020"
+ },
+ {
+  "TEKSTA_FRAGMENTS": ". „Varbūt arī es nogatavošos, mainīšu krāsu un kļūšu par zeltīti rozīgu brīnumu kā zeltainie cukurābolīši? Vai kļūšu saulei līdzīga kā bumbieri?” sapņoja cukurbiete Sana. 4. Nemanot pienāca rudens. Tīrumā sapulcējās cilvēki, izraka cukurbietes un iekrāva lielajos kravas auto. Cukurbiete Sana bija krietni izaugusi, bet skaistuma ziņā gan nebija mainījusies.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2019\/2020"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "5. Novāktās cukurbietes, arī Sanu, aizveda uz cukurfabriku. Tur viņu notīrīja, nomazgāja, sagrieza un iemeta lielā katlā. Un tad... notika pārvērtības! 6. Nepievilcīgā cukurbiete bija ieguvusi jaunu, skaistu, sniegbaltu izskatu. Viņa bija pārtapusi par cukuru! Cukurfabrikā Sana satikās ar visiem, kurus kādreiz bija apskaudusi krāsas dēļ. Nu, protams! Vai tad iespējams izvārīt ķiršu ievārījumu bez cukura? Nē! Bet kompotu? Džemu? Arī nē!",
+  "KLASE": 3,
+  "MACIBU_GADS": "2019\/2020"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Ar to vēl nebeidzās stāsts par cukurbieti Sanu. Konditorejas fabrikā viņai piešķīra dažādas krāsas, par kurām Sana priecājās: gan sārto ķiršu, gan dzintarkrāsas zeltīto, gan zaļgano. Šo krāsu paleti varētu vēl ilgi papildināt, bet labāk doties uz tuvāko saldumu veikalu un aplūkot visus krāsainos gardumus.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2019\/2020"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Cukurbiete Sana bija pārtapusi par krāšņu varavīksni. Tā priecēja visus, kuri to ieraudzīja. Katrā no mums ir tik daudz neatklāta skaistuma un patiesu vērtību! Ārējais skaistums ir maldinošs.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2019\/2020"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Latvijas kultūras vēsture nav iedomājama bez Raiņa un Aspazijas. Jau kopš 19. gs. beigām bijusi nepārtraukta interese par Raiņa un Aspazijas dzīvi un daiļradi. Dzejnieku daiļradei veltītas grāmatas, neskaitāmas zinātniskās konferences, viņu dzīve atainota literārajos darbos – lugās un biogrāfiskajos romānos.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2019\/2020"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Neraugoties uz to, ka Raiņa un Aspazijas dzīve un daiļrade ir daudz pētīta, arvien vēl palikuši neatbildēti jautājumi, arī tādi jautājumi, uz kuriem nevar dot tikai vienu pareizu atbildi. Tāda ir arī problēma, kas saistīta ar abu dzejnieku vārdiem. Diezin vai daudzi zina, ka dzejā pazīstamie vārdi Rainis un Aspazija ir dzejnieku pseidonīmi jeb segvārdi – tas ir, izdomāti, aizgūti personvārdi, kurus lieto īstā vārda vietā. Tieši literāti un mākslinieki bieži vien izvēlas pseidonīmus.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2019\/2020"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Jāņa Raiņa īstais uzvārds ir Pliekšāns. Pseidonīmu Rainis viņš pieņem, sākdams publicēt paša sacerētos dzejoļus periodiskajos izdevumos. Par to, no kurienes un kā radies šis pseidonīms, ir atrodamas dažādas versijas. Viena no populārākajām ir saistīta ar paša dzejnieka vēlāk, 20. gadsimta 20. gados, vēstīto: „Mans pseidonīms man atrasts gadus 25 atpakaļ.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2019\/2020"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Man ļoti patika senlatviešu vārdi, latgaliešos, kur es dzīvoju jaunībā, es daudz tādu dzirdēju, no visiem man visvairāk iepatikās šis, kuru es lasīju vienā Latgales pagastā uz ceļa stabiņa, ar kādiem mēdz apzīmēt zemnieku taisāmos ceļa gabalus.” Interesants ir fakts, ka pirmais oriģināldzejolis, kas publicēts laikraksta „Dienas Lapa” 1895. gada 1. novembra numurā, parakstīts – J. Reinis. Savukārt jau nākamais dzejolis tajā pašā izdevumā 11. novembrī parakstīts atšķirīgi – J. Rainis. Domājams, ka pirmajā gadījumā parakstā ieviesusies drukas kļūda.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2019\/2020"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Tikpat ticama varētu būt versija, ka Latgalē dzejnieks dzirdējis kā Reiņa, tā Raiņa vārdu un nevarējis pieņemt lēmumu par pseidonīma izvēli. Šādas versijas jau sen rosinājušas zinātniekus meklēt cilvēkus ar Reiņa un Raiņa uzvārdu, kas tolaik dzīvojuši Latgales pusē.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2019\/2020"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "19. gadsimta 80. un 90. gadu iedzīvotāju reģistri liecina, ka vairākiem zemniekiem bija uzvārds Reinis, taču varēja atrast tikai vienu cilvēku ar uzvārdu Rainis. Tas bija zemnieks Andrejs Rainis, kura uzvārdu, iespējams, pieņēma un „aiznesa pasaulē” Jānis Pliekšāns, turpmāk dzejoļus un lugas parakstīdams kā Rainis. Interesanta ir arī vārda Rainis nozīme. Vārds rainis lietuviski nozīmē raibais.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2019\/2020"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "19. gadsimta beigās dzejnieka dzimtajā pusē Latgalē bija cilvēki ar uzvārdu – Raibs. Tas var liecināt par sakarību vai pat vienādību starp abiem uzvārdiem. Varbūt uzvārds Rainis te pārtapis latviskajā uzvārdā Raibais? Vai tikpat daudz neskaidrību ir arī Raiņa dzīvesbiedres, dzejnieces Aspazijas pseidonīma izvēlē? Laikam nē. Viņas pseidonīma izcelsmē noslēpumu maz, taču tas ir pasaules kultūras vēsturē zināms vārds.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2019\/2020"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Oficiāli nākamajai dzejniecei ir trīs vārdi – Johanna Emīlija Lizete. Bērnībā ģimenē viņu sauca par\nElzu, Elziņu. Skolas gados un vēlāk sabiedrībā viņa bija pazīstama kā Elza Rozenberga.\nGan skolas gados, gan pēc tam, dzīvojot mājās, viņa daudz lasa, interesējas par vēsturi, filozofiju,\nmācās grieķu un latīņu valodu un arī pati sāk rakstīt dzejoļus. Elzas skolotājs nojauš jaunās, aizrautīgās\nmeitenes talantu, un viņam šķiet, ka būtu jāatrod topošās dzejnieces raksturam un dzejai piemērots\npseidonīms.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2019\/2020"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Viņš iesaka Elzai saukt sevi par Aspaziju. „Kas ir Aspazija?” – jautā Elza, un skolotājs iedod viņai izlasīt Roberta Hammerlinga romānu „Aspazija”. Elza ir kā apreibusi no Hammerlinga stāsta par skaisto un gudro Aspaziju, Grieķijas valdnieka Perikla dzīvesbiedri, kas senajā Grieķijā iedvesmojusi filozofus un māksliniekus. Jā, Elza grib būt līdzīga šai sengrieķu varonei.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2019\/2020"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "1887. gada nogalē „Dienas Lapā” tiek publicēts Elzas Rozenbergas pirmais dzejolis „Jaunā gadā”, kuru autore paraksta ar vārdu – Aspazija. Šodien, vairāk nekā pēc 150 gadiem, lasot par latviešu dzejnieces dzīvi un iepazīstoties ar viņas daiļradi, var tikai brīnīties, cik pārsteidzoši precīzi tika izvēlēts Elzas Rozenbergas pseidonīms.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2019\/2020"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Rainis un Aspazija nav vienīgie latviešu dzejnieki, kuri „slēpušies” aiz pseidonīma. 2014. gadā izdota literatūrzinātnieka Ilgoņa Bērsona grāmata „Segvārdi un segburti. Noslēpumi un meklējumi”, kurā apkopoti materiāli par latviešu rakstnieku pseidonīmiem jeb segvārdiem. Tas ir nozīmīgs notikums, jo latviešu kultūras vēsturē šis ir pirmais un vienīgais šāda veida pētījums. Šifrēt pseidonīmu izcelsmi, pētīt to atbilstību rakstnieka personībai un darbiem arvien ir interesanti, kaut arī ne vienmēr atradīsim vienīgo pareizo atbildi uz jautājumu – kāpēc mākslinieka pseidonīms ir tieši šāds?",
+  "KLASE": 9,
+  "MACIBU_GADS": "2019\/2020"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Reiz kādā karstā vasaras dienā zēns ezera malā ganīja aitas. Aitas piederēja skopai un niknai saimniecei, kas lika zēnam bez atpūtas un atlīdzības strādāt no agra rīta līdz vēlam vakaram. Laiks tajā dienā bija tik karsts, ka ne izteikt, un ezers turpat blakus. Tāpēc zēns sadzina aitas kopā un gāja ezerā atvēsināties.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2019\/2020"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Tā nu gadījās, ka tanī pašā laikā ezerā nolaidās skaista varavīksne un uznesa puiku debesīs. Tur viņš ieraudzīja mājiņu, kas izskatījās kā liela sēne. Mājiņā viņš atrada vecu, sirmu vecīti, kurš lūdza: „Dēliņ, esi tik labs, izkurini pirti! Tik sen neesmu pirtī pēries!”",
+  "KLASE": 9,
+  "MACIBU_GADS": "2019\/2020"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Puika prata labi izkurināt pirti un ar prieku vecīša lūgumu izpildīja. Savukārt vecītis par paklausību un iejūtību viņam iedeva zelta olu, teikdams, ja puika to paberzēs, atskries mazs rūķītis un izdarīs visu, ko zēns liks. Zēns tūlīt pat izmēģināja, un tiešām – rūķītis bija klāt un prasīja, ko šis vēlas. Zēns atbildēja, ka grib tikt atpakaļ uz zemes. Rūķītis paņēma zēnu, un tas nemaz īsti nedabūja apskatīties, kad jau bija savas saimnieces mājas pagalmā.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2019\/2020"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Tur viņu satika dusmīgā saimniece un prasīja, kur šis bijis, ka aitas ezera malā atstājis vienas? Zēns izstāsta, ka bijis debesīs. Tad saimniece jautāja, vai viņas mirušo tēvu arī debesīs redzējis un kā viņam tur ejot? Puika atbildēja, ka redzējis gan, bet diez cik labi jau nu neejot, jo esot pamaz naudas. „Nu, ja tā,” sacīja saimniece, „es gribu, lai tu kādu drusku naudas aiznes tēvam uz debesīm.” „Kāpēc ne, dod tik šurp! Esmu ar mieru,” atteica zēns. Saimniece iejūdza karietē trīs zirgus, ielika tur trīs mucas ar zelta naudu un teica zēnam, lai brauc.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2019\/2020"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Puika negaidīja ne mirkli un devās ceļā. Viņš kā brauca, tā aizbrauca un dzīvoja labas dienas. Bet laiks gāja, ganu zēns izauga par staltu jaunekli, un viņam bija jāmeklē sieva. Tās zemes ķēniņam bija daiļa meita, bet ķēniņš bija apsolījis viņu atdot par sievu tikai tam, kas novilks viņai no pirksta gredzenu.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2019\/2020"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Daudzi jau bija izmēģinājuši, bet nevienam neveicās. Arī jauneklis kopā ar savu rūķīti nolēma izmēģināt laimi, un abi brauca uz ķēniņa pili. Tur viņus laipni uzņēma, labi pabaroja un padzirdīja ar dārgiem ēdieniem un dzērieniem. Ieraudzījis princesi, jauneklis tā sāka slavēt viņas daiļumu, ka princese klausīdamās aizmirsa sargāt gredzenu, kas kā zvaigznīte vizēja viņas pirkstā. Viņa sēdēja krēslā, bet roka bija nokarājusies uz leju, un rūķītis nemanot novilka princesei gredzenu no rokas.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2019\/2020"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Princesei nu gribot negribot bijis jāprecas. Jauneklis pret princesi un citiem ļaudīm vienmēr izturējies tik laipni, ka drīz vien princese viņu no sirds iemīlējusi. Jauneklis apprecējis princesi un kļuvis par ķēniņu, bet zelta olu kopš tā laika viņam vairs nevajadzēja. Un arī rūķītis pazuda. Varbūt aizgāja citiem palīdzēt?... Bet bijušais ganu zēns un princese dzīvoja ilgi un laimīgi.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2019\/2020"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Atlases laikā piedzīvoju satricinājumu, ko nebiju gaidījis. Tā kā man nebija sevišķas pieredzes ar šādiem konkursiem, sākumā pa galvu pa kaklu skatījos, kurš no atnākušajiem varētu būt aktieris. Bet diezgan ātri sapratu, ka šim konkursam var būt daudz lielāka jēga, tāpēc pieslēdzos katram cilvēkam – arī tam, par kuru piecās sekundēs sapratu, ka viņš mums nederēs.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2019\/2020"
+ },
+ {
+  "TEKSTA_FRAGMENTS": ". Iepazinu viņus. Jā, viņi ir citādi. Tik ļoti, ka pat nezinu, kurš no kura mācīsies. Jauniešiem, kam tagad ir deviņpadsmit, divdesmit, profesionālais pilnbrieds būs laikā no 2030. līdz 2050. gadam. Mēs runājam par nākotni, par kuru neko nezinām. Par kuru neviens neko nezina. Bet ir skaidrs, ka tā būs pilnīgi cita dzīve un pilnīgi citi cilvēki sēdēs teātra zālē. Līdz ar to nav pārliecības, vai mana gudrība un pieredze viņiem būs vajadzīga. Protams, es nerunāju par amata prasmi, tā jāapgūst.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2019\/2020"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Interesanti, ka šie jaunieši ir ļoti vispusīgi, nodarbojas ar šķietami nesavienojamām lietām. Un viņi ir neticami pozitīvi, kas ir ārkārtīgi mulsinoši… Mūsu jaunībā bija pieņemts, ka cilvēka dziļums obligāti ir saistīts ar drūmumu un depresivitāti.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2019\/2020"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Šai paaudzei tā nav. Esmu daudz domājis par paaudžu lietām. Mēs bijām dumpinieki – tie, kas trāpījāmies vēstures zobratos pārejā no sociālisma uz kapitālismu. Mēs nevienam neuzticējāmies, mums nebija autoritāšu, mēs zinājām, ka visur jāmeklē zemūdens akmeņi. Tie, kam tagad ir trīsdesmit gadu, tā sauktā hipsteru paaudze, jau ir pozitīvi, bet viņi ir vairāk pārņemti ar formu, nevis saturu.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2019\/2020"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Viņiem ir ārkārtīgi svarīgi, lai viss būtu stilīgi. Hipsteri ir postmoderna parādība, viņi spēlējas ar stiliem, dara to virtuozi un eleganti, tomēr jāatzīst, ka hipsteru paaudze visā pasaulē nav radījusi neko jaunu un savu. Savukārt tie, kas nupat sasnieguši divdesmit, ir interneta paaudze jau no dzimšanas, ar savu kodu sistēmu. Diemžēl interneta kultūrai ir tendence izdeldēt personību. Cilvēki, kas atšķiras no pārējiem, tiek atsijāti. Globalizācijas blakusefekts neizbēgami ir standartizācija – visi staigā vienādās drēbēs, visi vienādi domā… Bet tieši tas, ar ko katrs cilvēks atšķiras, kļūs aizvien lielāka vērtība.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2019\/2020"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Mēs apjūsmojam jauno paaudzi, bet man šķiet, ka tam, ko jūs saucat par 20. gadsimta pieredzi, patiesībā ir liela vērtība. Protams, ir. Nevaru noliegt, ka jūtos krietni pārāks par saviem Rietumu kolēģiem, jo man ir bijusi fantastiska iespēja piedalīties lielajā eksperimentā, kad mainījās iekārtas. Biju pietiekami jauns, lai nejustos traumēts, bet vienlaikus pietiekami vecs, lai spētu paņemt to dzīves izjūtu, kuras vairs nekad nebūs. Nevar ne izstāstīt, ne ar pirkstiem parādīt, no kurienes nāk 20. gadsimta smeldze…",
+  "KLASE": 12,
+  "MACIBU_GADS": "2019\/2020"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Varētu domāt, ka par teātri zināt visu. Kāpēc tas jums joprojām ir interesants? Pirms dažiem gadiem pieķēru sevi domājam, ka ikviena izrāde man ir kā antropoloģisks pētījums, jo katrs cilvēks atspoguļo to, kas viņu veido. Tas ir nenormāli, nenormāli, nenormāli interesanti, daudz interesantāk, nekā lasīt Šerloku Holmsu. Saprast cilvēku un viņa uzvedības cēloņus, saprast, kāpēc viņš ir tāds un kāpēc tā dara, tas ir īstais krimiķis jeb detektīvs.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2019\/2020"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Es nevaru būt nekas cits Kādam karalim piederēja brīnišķīgs dārzs. Tajā auga skaisti koki un krūmi. Ziedēja brīnišķīgas puķes. Karalis ļoti lepojās ar dārzu. Viņš bieži pastaigājās pa to un priecājās. Reiz karalis iegāja savā dārzā un uzreiz sajuta pārmaiņas. Puķes, koki un krūmi, kas parasti viņu sagaidīja ar līksmu sveicienu, bija nīgri, neapmierināti un bēdīgi.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2020\/2021"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Karalis devās pie varenā ozola un jautāja:\n- Kas noticis ar tevi? Kādēļ tu esi tik bēdīgs?\nOzols atbildēja:\n- Kā nebēdāties? Tu taču gribi ar mani lepoties, bet kā gan to vari darīt, ja neesmu tik garš kā priede!\nKaralis devās pie priedes un jautāja:\n- Par ko tu esi noskumusi?",
+  "KLASE": 3,
+  "MACIBU_GADS": "2020\/2021"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Priede atbildēja:\n- Tu taču gribi ar mani lepoties? Kā gan tu to vari darīt, ja man nav maigu lapu, bet ir tikai asas skujas.\nKaralis gāja pa dārzu un dzirdēja, ka roze ir neapmierināta tādēļ, ka tai nav tik brīnišķīgu ogu ķekaru kā vīnogai, bet vīnoga ir noskumusi, jo tai nav tik krāšņu ziedu kā rozei. Jasmīns bēdājās, ka tā ziedi ir tikai balti, ceriņš gribēja būt mūžam zaļš.\nKaralis klausījās un jutās nelaimīgs, jo augi neprata lepoties ar sevi. Tie vēlējās to, kas ir citiem.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2020\/2021"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Pēkšņi karalis sajuta, ka no viena dārza stūra tomēr plūst gaisma, miers un siltums. To izstaroja pavisam mazs ziediņš, un tā bija neaizmirstulīte. Sīkā stādiņa ziedēšanas prieks pārspēja skumjo noskaņu dārzā. Neaizmirstulīte vienkārši ziedēja. Tā bija tik svaiga un koša! Redzot izbrīnu karaļa acīs, viņa teica:",
+  "KLASE": 3,
+  "MACIBU_GADS": "2020\/2021"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "- Esmu pārliecināta, ka tu šeit vēlējies redzēt tieši neaizmirstulīti. Ja tu šai vietā būtu vēlējies redzēt ozolu, vīnogas vai rozi, tu būtu stādījis tos. Es nevaru būt nekas cits kā vien neaizmirstulīte. Tikai tā es būšu laimīga un darīšu laimīgus citus. (Austrumu tautas pasaka)",
+  "KLASE": 3,
+  "MACIBU_GADS": "2020\/2021"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Pirms daudziem gadu tūkstošiem cilvēks pieradināja suni.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2020\/2021"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Ziemeļos, kur septiņus mēnešus gadā valda ziema, ir slikti laika apstākļi un nekursē transports, pajūgu suņi ir kļuvuši par neaizstājamiem cilvēku palīgiem.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2020\/2021"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Pasaulē pazīstamākie pajūgu suņi ir haskiji Balto un Togo.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2020\/2021"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Kad 1925. gada ziemā Aļaskas pilsētā Nomē smagi saslima bērni, pilsētā nebija zāļu. Pēc zālēm ar kuģi nokļūt nevarēja, jo ūdenstilpnes bija aizsalušas. Sniega vētras dēļ nelidoja lidmašīnas un nekursēja vilcieni.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2020\/2021"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Lai glābtu saslimušos, ceļā devās 20 suņu pajūgi. Galvenā pajūga priekšgalā bija suns Togo ar savu saimnieku. Togo bija 12 gadus vecs haskijs tumši brūnā krāsā, augumā krietni mazāks par saviem sugas brāļiem, bet ļoti veikls un drosmīgs.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2020\/2021"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Lai ātrāk sasniegtu tuvāko pilsētu, pajūgs šķērsoja trauslo jūras ledu. Kad ledus gabals atrāvās no krasta, Togo izglāba saimnieku un citus suņus. Viņš brīdināja savu saimnieku par plaisām ledū, tumsā izvēlējās pareizo virzienu un pārējos suņus mudināja neapstāties.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2020\/2021"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Pēdējo bīstamā skrējiena posmu veica haskija Balto un viņa saimnieka vadītais suņu pajūgs. Balto bija melns ar baltām ķepām un viens no jaunajiem haskijiem, kuram līdz šim vēl nebija uzticēti svarīgi uzdevumi. Taču pēc skrējiena 50 grādu salā, stiprā vējā un puteni, Balto kļuva par varoni, jo viņa pajūga piegādātā zāļu vakcīna izglāba daudzu pilsētas bērnu dzīvības.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2020\/2021"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Attālumu, ko labos laikapstākļos suņu pajūgi parasti noskrēja divās nedēļās, Togo un Balto pieveica piecās dienās. Par abu suņu varoņdarbu uzņemtas filmas un sarakstītas grāmatas. Balto un Togo piemiņai Amerikā uzcelti pieminekļi.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2020\/2021"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Linda Kusiņa-Šulce. Īpašvārdu atveides tradīcija, ticams, atmirs\nAtšķirībā no rakstniekiem, kuri gluži teorētiski var palikt savā valodas komforta zonā, brīvi izvēloties\nizteiksmes līdzekļus, tulkotājiem jāspēj iejusties visdažādāko autoru stilā. Starp šīs jomas profesionāļiem,\nkam tas izdodas vislabāk – par to liecina gan lasītāju atzinība, gan profesionāļu balvas –, ir Maima\nGrīnberga, kura latviešu lasītājus iepazīstinājusi ar daudziem somu un igauņu rakstniekiem",
+  "KLASE": 9,
+  "MACIBU_GADS": "2020\/2021"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Ielasieties kaut šajā vienā fragmentā: „Mēs uzmetīsim medaināko garu pasaulē, vaivariņu garu, tādu, kas liek prātam rimt un dusēt zilgani sveķainā miegā vēl ilgas stundas pēc peldes.” Vai arī: „Izgāšlaikos brāļi māsas nelamāja un matus šamām nevienc nost nešņikāja. Kas tas i, ka visi taga grib sieviešus apcirpt?”",
+  "KLASE": 9,
+  "MACIBU_GADS": "2020\/2021"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "pt?” Kā apgūst šādu valodas lietojuma virtuozitāti? 1. Pieļauju, ka pat ļoti pieredzējušam tulkotājam noder vārdnīcu palīdzība. Kuras lietojat visbiežāk, un kādēļ tieši tās? M. Grīnberga: Vienmēr esmu bijusi atkarīga no vārdnīcām, esmu un būšu, jo neuzticos savai atmiņai un zinu, ka daudz ko nezinu. Agrāk tā bija grāmatu armāda, tagad – elektroniskie resursi. Kad tulkoju, vaļā stāv, „Latviešu literārās valodas vārdnīca”, „Mūsdienu latviešu valodas vārdnīca” un „Tēzaurs”. Vajadzības gadījumā – MEV, proti, Mīlenbaha un Endzelīna „Latviešu valodas vārdnīca”, tiesa, to man joprojām labāk patīk šķirstīt.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2020\/2021"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Vēl regulāri lietoju dažādas man noderīgas somu un igauņu skaidrojošās un tulkojošās elektroniskās vārdnīcas. Pat man labi zināmu svešvalodu (arī latviešu valodas) vārdiem var būt nozīmes, kas man ne sapņos nerādās. Nepārbaudīt katru kaut mazliet dīvainu vai aizdomīgu vārda lietojumu ir nolaidība.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2020\/2021"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Katrai valodai ir sava, ja tā var teikt, „pasaules karte”. Atšķirības teikumu uzbūvē ir būtiskas, cik zinu, igauņu un somu valodā pavisam citādi veido laikus – kā panākt, lai igauņu\/somu rakstnieki latviešu valodā izklausītos pēc sevis? Ir tāds jociņš – somugriem nav ne dzimuma, ne nākotnes. Proti, nav dalījuma sieviešu un vīriešu dzimtē, nav verba nākotnes formu. Visu nosaka konteksts un rakstnieka nodomi.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2020\/2021"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Manai mīļajai Rozai Liksomai ir vairāki teksti, kur monologa runātāja dzimums atklājas tikai pēdējā teikumā. Tā kā viņas valoda bieži ir ļoti groteska, dialekta iekrāsota, risinājumu var atrast. Grūtāk ir neitrālāka reģistra tekstos, kur pārgalvīga izdarīšanās nav pieļaujama. Neko darīt, piemēram, Emmi Iterantas grāmatas „Ūdens atmiņa” latviešu un citu indoeiropiešu valodu tulkojumu lasītāji galvenās varones dzimumu uzzina nedaudz agrāk kā somu lasītājs.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2020\/2021"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Ar autores piekrišanu. Arī Tommi Kinnunena „Četru ceļu krustojuma” ievads dažos tulkojumos ir mazliet nodevīgāks nekā somu oriģināls, taču arī šajā gadījumā autors teica, ka tas nav tik svarīgi. Tulkotājam jāizsver un jāizsāp, no kā var atteikties, kas ir prioritārs, kad un cik apjomīgi var mainīt teikumu, autora vēstījuma struktūru.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2020\/2021"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Vēl joprojām atkal un atkal mēdz atskanēt paziņojumi, ka latviešu valoda nav pietiekami bagāta šim vai tam. Kā izjūtat latviešu valodas bagātību, daudzveidību, vai ir kāda joma, kur bijušas grūtības piemeklēt autora izteiksmei atbilstošu latviešu vārdu? Galvenais ir uztvert pareizo reģistru, un gan jau tad vajadzīgie risinājumi atradīsies (protams, izņemot gadījumus, kad neatrodas un nemaz nav iespējams atrast, tādu tekstu labāk vienkārši netulkot). Reizēm man šķiet, ka somu un igauņu valodā ir bagātāks skaņu atdarināšanas arsenāls. Un bieži gribas šīs valodas apskaust par vieglumu, ar kādu tiek radīti jauni salikteņi, cik cak, gatavs – un neviens nebrīnās.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2020\/2021"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Kā ar īpašvārdiem, kurus mēs latviešu valodā spītīgi cenšamies atveidot pēc izrunas? Mēdz taču būt personāžu vārdi, kuriem svarīga gan to nozīme, gan skanējums. Vai varat atklāt kādus piemērus, kad nācies krietni palauzīt galvu? Pret īpašvārdu atveidi man ir divējādas… jā, jūtas. No vienas puses, man šī tradīcija patīk kā interesants rēbuss un oriģinalitāte. Traku padara tas, ka nav iespējama konsekvence.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2020\/2021"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "No otras puses, visticamāk, jau tuvā nākotnē šī tradīcija atmirs. Par to parūpēsies sociālie mediji ar visām ietagošanas iespējām un tamlīdzīgi. Acs pieradīs pie tā, ka īpašvārdi netiek atveidoti. Viss oriģinālā, viss nominatīvā. Un tad nu mani pat vairāk uztrauc, ka pamazām izzudīs arī personvārdu deklinēšanas prasmes. Pirmajā reizē, kad radio „Klasika” kāda raidījuma vadītāja pateica „Friča Bārda vārdi”, es domāju, ka cilvēks pārteicies. Taču tad viņa to pateica vēlreiz… un arī drukātā vārdā tādi brīnumi ir redzēti. Nu, cerams, es tomēr pārspīlēju.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2020\/2021"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Tāpat tulkotājam neizbēgami laiku pa laikam nākas jaunveidot – kaut vai tikai vienas grāmatas dēļ – pašam savus jaunvārdus. Kuri pašai ir vismīļākie no sevis izveidotajiem vai varbūt – no vārdnīcu dziļumiem izceltajiem? Uz jaunveidotājas godu es laikam tomēr nepretendētu… Lielākoties viss ir labi aizmirsts vecais un zināmais, varbūt tikai jaunās skaņās. Nu labi, kaut kādas ēverģēlības bija Miko Rimminena „Alus tarbas romānā”, bet tas bija tik sen, ka viss pagaisis no atmiņas.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2020\/2021"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Atceros tikai, ka man brangi patika tulkot un bij’, ko ņemties. Ar izloksnēm esmu spēlējusies un ar dažiem risinājumiem esmu apmierināta, piemēram, Katjas Ketu romānā „Vecmāte”. 6. Vai tulkotāju vidē pastāv neformāla diskusiju vide par jēdzienu atveides un tulkošanas lietām?",
+  "KLASE": 9,
+  "MACIBU_GADS": "2020\/2021"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Man ir vairāki kolēģi, kuriem prasu padomu, ar kuriem apspriežos. Dace Meiere, Silvija Brice, Māra Poļakova, Dens Dimiņš, Vineta Berga, Dace Deniņa, Ingmāra Balode, Jānis Krastiņš u. c. Lieliskais redaktors Arturs Hansons. Arvien biežāk izkliedzu jautājumus arī sociālajos medijos: agrāk tā kautrīgi „Cibā”, pēdējā laikā jau drosmīgāk – feisbukā. Tiesa, ir daudzas problēmas, ko var saprast tikai cits tulkotājs, bet, kolīdz ir stāsts par sarunvalodu, terminu reālo lietojumu, nozaru idiolektiem* un tamlīdzīgi, un tāds spēks ir grandiozs palīgs.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2020\/2021"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Runāt par literatūru ir vienkārši un aizraujoši, ja sarunu biedri ir draugi vai paziņas. It īpaši, ja apspriežamās grāmatas ir svaigā atmiņā. Vislabākās literārās diskusijas esam aizvadījuši virtuvēs, pie ugunskuriem vai garās pastaigās pa pilsētām, mežiem un tamlīdzīgi. Pavisam citādi ir uzrunāt plašu publiku – ne tikai aizrautīgus lasītājus, bet arī tos, kuru apziņā Raiņa, Jaunsudrabiņa un citu klasiķu darbi (arī paši klasiķi) jau kopš skolas laika pārtapuši par skaistiem pieminekļiem.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2020\/2021"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Nepārprotiet, pieminekļiem nav ne vainas, tie ir svarīgi un nozīmīgi, taču runāt par tiem ikdienišķi, bez liekas jūsmas, vēl jo vairāk – no televizora ekrāna, un ieinteresēt skatītāju… Lūk, tas jau ir diezgan āķīgs uzdevums.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2020\/2021"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Nevaru vien nopriecāties, cik eleganti un gaumīgi tas izdevies Vides filmu studijai un raidījuma „Literatūre” veidotāju komandai. Līdz šim nez kāpēc biju iedomājies, ka dokumentālas pārraides par iepriekšējo gadsimtu literātiem drīkst taisīt tikai stereotipiski: biogrāfija un bibliogrāfijas izklāsts, laikabiedru atmiņas un arhīvu materiāli, visam pāri – nesatricināma nopietnība.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2020\/2021"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "„Literatūrē” šie elementi gandrīz vienmēr ir saglabāti, taču režisors Uģis Olte kopā ar raidījuma vadītājiem Martu Selecku un Gustavu Terzenu tos piedāvā saprotami, viegli, reizēm pat rotaļīgi.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2020\/2021"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Raidījums ir kā spēle. Un, kā vairumā spēļu, arī šeit noteikumi tiek izklāstīti katras sērijas ievadā: literatūriste (cik apskaužams apzīmējums!) Marta kopā ar kādu no mūsdienu rakstniekiem vai rakstniecēm ceļo pa klasiķu dzīves vietām, kamēr literatūrists Gustavs, bruņojies ar grāmatām, ceļo vienatnē, uzrunādams garāmgājējus un autoru novadniekus.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2020\/2021"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Izklausās vienkārši. Taču „Literatūres” šķietamo vieglumu papildina daudz smalku detaļu. Kaut vai tas, ka raidījuma viesi, mūsdienu autori, runā par sev tuviem pagātnes rakstniekiem (Guntis Berelis – par Regīnu Ezeru, ar kuru iepazinies jaunības gados, Luīze Pastore – par Zentu Ērgli, savulaik bērnu grāmatu populārāko autori, bet Andris Akmentiņš, būdams Valmieras puika, – par Pāvilu Rozīti).",
+  "KLASE": 12,
+  "MACIBU_GADS": "2020\/2021"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Katrs no šiem vēstījumiem tikpat labi varētu palikt izglītojošas lekcijas rāmjos un būt ne mazāk noderīgs. Taču prasmīga režisora rokās pat visvienkāršākais sižets apaug ar savdabīgu noskaņu un estētiskām niansēm, kas sausus faktus, ja tā var teikt, paceļ jaunā mākslinieciskā līmenī.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2020\/2021"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "„Literatūrē” ir kaut kas no road movie žanra laiskās burvības. Kaut vai tas, ka raidījumos ir divas paralēlas sižeta līnijas. Vienā no tām Gustavs iepazīst literatūru patstāvīgi, neiesaistot rakstniekus. Apmeklēdams dažādas ar autora dzīvi un darbiem saistītas vietas, viņš rosina (reizēm pat piespiež) nejaušus garāmgājējus padomāt par grāmatām, kas vai nu nav lasītas, vai, tieši otrādi, ir lasītas un pārlasītas.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2020\/2021"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Šo daudzveidību vieno kvalitatīva montāža, kas neuzbāzīgi pārslēdzas no stāsta uz stāstu, neļaujot tiem pārāk sapīties. Rakstnieku dzīvesstāsti tiek papildināti ar dokumentāliem kadriem, pagātnes maršruti tiek izstaigāti mūsdienās, un pēkšņi tu attopies, ka esi noskatījies sešus raidījumus, nevis vienu, kā bija paredzēts, un patiesībā tev jau sen bija jāliekas uz auss, bet tā vietā tu šķirsti Raiņa kopotos rakstus, kas nekādā ziņā nebūtu noticis, ja vien Inese Zandere „Literatūrē” nebūtu par viņu tik aizrautīgi stāstījusi, uz baržas celdamās pāri Daugavai. Šie ceļojumi ir tik vilinoši un gandrīz katram pazīstami. Tādi, kam gribas veltīt brīvu nedēļas nogali – pabraukāties, palasīt, parunāties. Kā virtuvēs un pie ugunskuriem, kā klasiskajos roudmūvijos un īstos ceļojumos. Svarīgākais ir ceļš, nevis galamērķis.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2020\/2021"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Dabas, ceļojumu un piedzīvojumu mīļotāji kopā ar lamu Atakamu un pingvīnu Humboltu Humboltu iepazīst Čīles brīnumaino dabu. Abi grāmatas galvenie varoņi nav apmierināti ar savu mājvietu un dodas jaunas mājas meklējumos. Ceļā viņi piedzīvo bīstamus notikumus, pārvar negaidītus šķēršļus, satiek dažādus tuksnesī un okeānā mītošus dzīvniekus, uzzina par augiem.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Grāmatā kāda trīs bērnu ģimene dodas apskatīt Rīgas torņus un iepazīt pilsētas arhitektūru un vēsturi. Autoru stāstījumu papildina mākslinieces ilustrācijas ar pilsētas skatiem un Rīgas karte. Autores aicina ikvienu lasītāju doties ekskursijā pa Latvijas galvaspilsētu.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Kopā ar grāmatas varoni Oleku lasītāji var doties aizraujošā ceļojumā pāri Atlantijas okeānam, kā to darīja Aleksandrs Doba – pirmais cilvēks pasaulē, kurš šķērsoja Atlantijas okeānu. Grāmatas lappusēs var izlasīt, kā ceļotājs vētras laikā vārīja kafiju, jūsmoja par zibens spērieniem un pērkona dārdiem, ko darīja, kad tīģerhaizivs ar galvu triecās pret laivu.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Pasakā meitene Ella un viņas uzticamais draugs – suņuks Totoška – nejauši nokļūst brīnumainā Smaragda pilsētā. Lai varētu atgriezties savās mājās, meitenei jādodas pie varenā un briesmīgā burvja Gudvina. Tikai burvis var piepildīt ceļā sastaptā Putnubiedēkļa, Lauvas un Dzelzsgriezēja karstākās vēlēšanās, un tas savukārt ļautu meitenei doties mājup.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Dzejoļu krājumā autore aicina bērnus ievērot drošību, lai izvairītos no bīstamām situācijām un traumām.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Stāstījums pasakas formā ir par latviešu rotaļu lāča Tobiasa un viņa drauga – japāņu kaķa Tamas – ceļojumu apkārt Baltijas jūrai. Ceļojuma laikā abi varoņi iepazīstas ar 10 Eiropas valstu bibliotēkām un iemīļotiem pasaku varoņiem – Loti, Muminu, mazo Nāriņu, Vinniju Pūku, Billi, Niku Holgersonu un citiem.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Tas ir stāsts par trusi Tru, kurš parūpējās par diviem cilvēku pamestiem kucēniem, lai tie spētu izdzīvot ziemas bargajos apstākļos. Grāmatā var pārliecināties par to, ka arī dzīvnieku pasaulē līdzjūtība un sirds siltums pret nelaimē nonākušo dara brīnumus.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Es ieteiktu izlasīt šo grāmatu tādiem cilvēkiem, kam patīk ceļot pa eksotiskām valstīm un rakstīt dienasgrāmatu par redzētajiem dabas objektiem, dzīvniekiem un augiem. Ja es gribētu kļūt par biologu, tad noteikti izvēlētos lasīt šo.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Kad cilvēks izlasa šo grāmatu, viņš saprot, kā jūtas pamesti dzīvnieki. Brīvdienās es bieži dodos uz dzīvnieku patversmi, lai izvestu pastaigā savu mīļo Džeri. Ļoti ceru, ka mamma kādreiz man atļaus suni vest uz savu māju. Es nekad sunīti nepametīšu.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Ja tu vēl neesi bijis Nacionālajā bibliotēkā, tad izlasi šo grāmatu! Tu uzzināsi par arhitektu G. Birkertu un bibliotēkas būvniecību. Man ļoti patika arī tas, kā citu valstu pasaku varoņi iepazīstināja ar savu valstu bibliotēkām. Dažu pasaku varoņus es zināju, bet par pārējiem noteikti gribētu uzzināt vairāk.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Man patika, ka šo grāmatu klasē lasījām kopā. Katrs skolēns izteiksmīgi izlasīja vienu dzejoli, bet klasesbiedri pēc tam izteica savas domas par dzirdēto.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Kad skolotāja sociālo zinību stundā lūdza mūs uzrakstīt par cilvēku, kuram es gribētu līdzināties, es rakstīju par Aleksandru Dobu. Drosmīgi stāties pretī vētrām, kas liek viļņiem sasniegt vairāku mājas stāvu augstumu, un prast par to vēl pajokot, manuprāt, ir apbrīnojami.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Tā kā es dzīvoju Rīgā netālu no Ugunsdzēsības muzeja, biju priecīgs, kad grāmatā lasīju par pazīstamo torni. Ar interesi izlasīju arī par citiem Rīgas torņiem. Nākotnē gribu kļūt par arhitektu, tādēļ rūpīgi pierakstīju, kā sauc ēku daļas.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Manai mazajai māsai pirms gulētiešanas ļoti patīk klausīties pasakas. Es viņai tās lasu priekšā. Ja tajās aprakstīti tādi neparasti un brīnumaini notikumi kā burvju pilsētā, tad grāmatas ieinteresē arī mani.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Pagājušajā gadā Latvijas Dabas muzejs pirmo reizi par gada dzīvniekiem ir atzinis divus – balto zaķi un pelēko zaķi. Latvijā dzīvo abas zaķu sugas. Baltais zaķis pie mums ir senāks nekā pelēkais zaķis, un par savu mājvietu viņš ir izvēlējies mežu.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Pelēkais zaķis ir lielākais no abām Latvijā sastopamajām zaķu sugām. Tam ir garākas kājas. Tās ļauj veikli pārvietoties pa pļavu un laukiem. Baltais un pelēkais zaķis kažoka krāsu maina divas reizes gadā – pavasarī un rudenī. Vasarā abiem zaķiem apmatojums ir rūsganpelēks. Vienīgi pelēkajam zaķim tas ir mazliet gaišāks. Pelēkā zaķa asti rotā melnas krāsas plankums. Ar to tas atšķiras no sugas brāļa.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Ziemā tikai baltais zaķis kļūst pilnīgi balts. Sniegā var saskatīt vienīgi viņa melnos ausu galus. Zaķa pēdas ir platas un biezi apmatotas. Tā viņš var viegli pārvietoties pa sniegu. Ja ziemā nav sniega, baltais zaķis ir ātri pamanāms, tādēļ viņš kļūst par vieglu laupījumu vilkam, lapsai, lūsim, caunai, ērglim un citiem plēsīgiem dzīvniekiem.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Zaķi spēj skriet ātrāk par 50 kilometriem stundā un skrējiena laikā bieži mainīt virzienu. Viņiem ir laba dzirde un sānu redze, kas ļauj saklausīt un ieraudzīt ienaidnieka tuvošanos pat no aizmugures. Tā kā zaķis spēj saskatīt tikai kustīgus objektus, tad reizēm pats uzskrien virsū ienaidniekam. Pelēkā zaķa ausis ir garākas nekā baltā zaķa ausis. Abiem dzīvniekiem tās palīdz vasaras karstajās dienās nepārkarst.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Abu sugu zaķi biežāk ēd krēslā un naktī. Zaķiem ir stipri, graušanai piemēroti zobi. Tie aug visu mūžu. Baltais zaķis vairāk pārtiek no kokaugiem, bet pelēkais – no vieglāk un zemāk pieejamas pārtikas – labības un pļavu augiem. Lai ziemā piekļūtu barībai, pelēkais zaķis izrok sniegā bedres līdz pat 30 centimetru dziļumam. Zaķu mammām mazuļi dzimst divas vai trīs reizes gadā. Nedēļu pēc piedzimšanas zaķēni jau paši ēd zāli, bet pēc mēneša kļūst pilnīgi patstāvīgi.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Jūnijā Ulsiks ar lielu nepacietību gaida Zāļu vakaru un Jāņus. Ulsiks zina, ka būs liela ņemšanās, ugunskuri un, galvenais, varēs ilgi palikt augšā. Ne jau nu visu nakti, bet gandrīz… 2. Tagad, kad viņiem pašiem ir savs dārzs, līgot brauks gan vecāku vadīto koru dalībnieki, gan vīri no „Tēvzemes”.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Tas ir koris, kurā dzied vien onkuļi. To diriģē Mednis, Ulsiks zina, jo mamma un tētis ar viņu draudzējas, brauc ciemos, rīko kopīgus koncertus saviem koriem. Vēl vecāki draudzējas ar vienu igauņu vīriešu kori un viņu vadītāju Ernesaksu. Ulsiks ir bijis viņu koncertā, tomēr nesaprot, vai viņš arī citreiz diriģē lielo kori vai savā zemē ir tikai komponists.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Jau no agra rīta, kamēr mamma un oma rosās pa virtuvi, tētis un Ulsiks brauc uz pļavām. Tepat dārza žogmalē Ulsikam vajadzīgās pīpenes tādā daudzumā nesaplūksi. Ulsikam vajag daudz, jo viņam ir radusies kāda pušķošanas ideja. Ulsikam vispār ļoti patīk ņemties ar puķēm.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Viņi atrod lielisku pļavu – tur pīpeņu balto ziedlapu vainadziņi ap dzeltenajām viduču saulēm cits pie cita. Ulsiks saplūc arī sarkanā āboliņa pušķi, un blakus, labības laukā, tētis pat atradis zilās rudzupuķes. Atceļā viņi vēl salauž lērumu ozola zaru un pārrodas ar milzīgu jāņuzāļu kravu.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "– Kur tad šito visu liks? – Omīte notes pēc pukojas. – Liec puķes te, labi, ka mums pielijusi pilna tā lietusūdens vannīte. 6. Ulsiks atceras Jāņus, kad modē bija papīra indiāņu galvasrotas, kovboju cepures un kartona vainagi ar kreppapīra lentēm. Mamma teica – košie papīra vainagi un kovbojnieces esot kas šausmīgs. Ja nav Jāņu, tad lai arī nav. Tā esot tāda svētku izsmiešana. Tagad Ulsiks zina, ka īstais skaistums aug pļavās.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Ulsikam jāsteidzas, laika ir maz, jo jāpagūst sapīt garās vijas. Jā, Ulsiks ir izdomājis ap visiem trim verandas stabiem apvīt margrietiņu vijas. Pin un pin, nez cik metru jau novīts, brīnums, ka puķes nav beigušās. Ulsiks saprot, ka nepietiks. Labi, ka tētis mežā nocirtis meiju, pieliks bērziņu. Bet divi stabi izskatās pasakaini.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": ". Zālē vēl guļ pāris pīpeņu. Ulsiks sāk pa vienai raut nost baltās ziedlapiņas un klusiņām dudināt „mīl, nemīl, mīl, nemīl”, un pie pēdējās, kas vēl turas pie zeltainā viduča, sanāk „mīl”. Nu re, viss kārtībā. 9. – Kurš tad ir tas laimīgais? – Omas jautājums Ulsiku pārsteidz nesagatavotu. Ulsiks piesarkušiem vaigiem kā raķete aiztraucas prom.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "– Pīrāgi sacepti, siers ir, nu tik jāgaida līgotāji. – Šoreiz Oma šķiet gaužām mierīga. 11. Ulsikam vēl jāsapin ozolzaru vainagi. Un ziedu vainadziņi. Ulsiks izprasa striķus. Citādi ozolus nav iespējams dabūt vainaga ripulī. Paiet labs laiciņš, un līdzās zālītē jau guļ divi gatavi ozollapu kroņi. Mammai vainags nopīts no sarkanā āboliņa.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Ulsiks piktojas, ja kāds par viņa skaisto darbu neizrāda prieku pietiekami skaļi. Ulsiks tak tā centās! 12. Pa vārtiem nāk līgotāji, dziedādami dažādas dziesmas. Starp viņiem Kačiņa un Harītis. Arī šoreiz viņu Jāņu pušķis ir krietns, bet viņi atnesuši vēl kaut ko – četrus mazus ozoliņus.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Ir tak katram dzīvē koks jāiestāda, vislabāk ozols Līgo vakarā, – Harītim vienmēr ir kāds sakāmais. 14. Viņi sameklē ozoliem vietu līdzās maijpuķīšu pļaviņai, visi nedaudz padarbojas ar lāpstu, un kociņi ir iestādīti. 15. – Nu mums būs pašiem sava ozolu birzs, – mamma saka",
+  "KLASE": 6,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "6. Beidzot viņi dodas uz ezermalu. Tur jau iedegti ugunskuri – cits mazāks, cits milzīgs. 17. „Kas gulēja Jāņu nakti, līgo, līgo, tas guļ visu vasariņu,” līgotāju dziesma galvai liek klanīties vēl vairāk. 18. – Šitas līgotājs saulīti nesagaidīs, jānogādā drošībā, – Ulsiks šos vārdus dzird jau pavisam neskaidri, tēvs paceļ meitu uz rokām. Otrā rītā Ulsiks pamostas savā gultiņā.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Latvijas Skolu jaunatnes dziesmu un deju svētki jeb Svētki ir nozīmīgākā bērnu un jauniešu dziesmu un deju tradīcija Latvijā. Vēsture saistāma ar 1866. gada 18. jūliju, kad Praulienas pagasta Mācītājmuižā notika bērnu dziedāšanas svētki. Latvijas Skolu jaunatnes dziesmu un deju svētku tradīcija aizsākusies 1960. gadā, kad 23. jūnijā Rīgā no 178 Latvijas skolām sapulcējās vairāk nekā 8,5 (astoņi, komats, pieci) tūkstoši jauniešu. Pirmo Svētku repertuārā bija iekļautas 23 dziesmas un 15 dejas.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Saskaņā ar Dziesmu un deju svētku likumu Svētki notiek reizi piecos gados starplaikā starp Vispārējiem latviešu dziesmu un deju svētkiem. Līdz šim ir notikuši divpadsmit Latvijas Skolu jaunatnes dziesmu un deju svētki. Dziesmu lielkoncerti notiek Mežaparka Lielajā estrādē, bet deju lielkoncerti – Daugavas stadionā. Covid-19 ierobežojumu dēļ pēdējie XII Svētki bija citādi, to moto bija: „Svētki ir tur, kur esam mēs”, veltot vislielāko uzmanību katram kolektīvam, katram dalībniekam.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Vislielākais skatītāju un dalībnieku skaits bija 2015. gadā notikušajos XI Svētkos, kuros dalībnieku vien bija 37 890. Visvairāk interesentu un dalībnieku pulcēja deju lielkoncerts, Svētku gājiens, pūtēju orķestru lielkoncerts un noslēguma koncerts. Šajos Svētkos pirmo reizi piedalījās diasporas pārstāvji, tas ir, jaunieši, kas, dzīvojot ārpus Latvijas, kopj latviskās tradīcijas. XI Svētkos piedalījās 16 939 dejotāji un 12 704 dziedātāji.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "XI Svētku programmu veidoja koru, vokālo ansambļu, deju kolektīvu, mūsdienu deju kolektīvu, pūtēju un simfonisko orķestru, instrumentālo ansambļu, mazo mūzikas kolektīvu sniegums. Svētku laikā bija arī radošās darbnīcas, teātru izrādes un citas aktivitātes, piemēram, Bastejkalnā atradās Enerģijas stabules, kurās ikviens interesents varēja radoši savienot skaņu un deju, iemēģinot lielo klaviatūru, ērģeļu stabules un zvanstabules.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "2015. gadā pirmo reizi Skolu jaunatnes dziesmu un deju svētku vēsturē dalībnieki paši varēja kļūt par Svētku reportieriem. Sadarbībā ar Svētku atbalstītājiem īpašā konkursā tika atlasīti pieci atraktīvi, komunikabli, zinātkāri un žurnālistikas nozarē ieinteresēti Svētku dalībnieki. Konkursa uzvarētāji saņēma jaunus viedtālruņus un interneta pieslēgumu bez ātruma un apjoma ierobežojuma, lai ātri un veiksmīgi sagatavotu dažādu formātu reportāžas.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Viņiem bija iespēja iekļūt ikvienā Svētku pasākumā gan mēģinājumu, gan koncertu laikā, kā arī satikt un intervēt Svētkos iesaistītos māksliniekus. Jaunajai reportierei Elizabetei no Rīgas 3. Valsts ģimnāzijas bija iespēja ceļot pa svētku norises vietām kopā ar Latvijas Televīzijas filmēšanas grupu un atspoguļot savas izjūtas svētku dienasgrāmatā. Ieklausies, ko raksta Elizabete!",
+  "KLASE": 6,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "1. DIENA. Pēcpusdienā bijām Ķīpsalā, kur norisinājās ģenerālmēģinājums mūsdienu deju lielkoncertam „Te mēs esam”. Jau ģenerālmēģinājumus apmeklē daudz cilvēku – visas sēdvietas aizņemtas. Vislielāko iespaidu no ģenerālmēģinājuma atstāja videoinstalācijas, kas labi papildināja dejotāju uzvedumus. Videoinstalācijās bija sameklēti daudzveidīgi videomateriāli no interneta dzīlēm, kas noteikti uzrunā jauniešus.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": ". Bez tā visa priekšnesumā piedalījās arī grupa „Instrumenti”, kas pirms uzstāšanās gan nebija pārāk runīgi un atvērti garām sarunām, kas ir saprotams, jo viņiem bija jākoncentrējas savam uznācienam. Bet ar visu to, grupa „Instrumenti” bija gatavi intervijai un fotogrāfijām. Vārdu sakot, svētki ir svētki, un te viss ir kā tādos – iepazīšanās, tikšanās, fotografēšanās un runāšanās. Un svētki tik tikko ir sākušies!",
+  "KLASE": 6,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Mežaparks. Svētku noslēdzošais koncerts. Bez komentāriem. Dziesmas paķēra līdzi, it īpaši tās, kurām bija zināmi vārdi. Tieši tie bija brīži, kuros bija jūtama vienotības sajūta un mēs visi bijām vienoti dziesmā.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Neizskaidrojami. “Saule, Pērkons, Daugava” un “Mana dziesma” ar Renāra Kaupera piedalīšanos bija vakara spridzekļi. Cilvēki cēlās kājās, dziedāja un gavilēja pēc dziesmām, un lūdza tās atkārtot. Pēkšņi bija silti, enerģijas un prieka savienojums virmoja visapkārt un manī pašā. Kaut izdotos šādas emocijas piedzīvot klātienē XIII Latvijas Skolu jaunatnes dziesmu un deju svētkos!",
+  "KLASE": 6,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Silīcija ielejas miljonāri ir panikā, jo viņu bērni pārāk daudz lieto viņu ražotos produktus. Pēdējo pāris gadu laikā aizvien vairāk jauno tehnoloģiju ieviesēju nolēmuši, ka bērniem līdz 15 gadiem būtu jāturas, cik vien iespējams, tālu no ekrāniem, to lietošana tiek ierobežota. Paši jauno tehnoloģiju radītāji zina, ka viedtālruņu un sociālo tīklu dizains tiek veidots, lai radītu cilvēkos atkarību, vēlmi iegādāties arvien jaunāka modeļa ierīci, atgriezties savos sociālo tīklu kontos. Jo ilgāk lietotāji kā nozombēti blenž ekrānos, jo vairāk reklāmu viņiem var parādīt, jo vairāk naudas var nopelnīt.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Jauno tehnoloģiju radītāji redz, ka „viedtālruņu kūkuma poza”, kad roka lūdzoši izstiepta, acis pienaglotas ekrānam plaukstā, mugura neveselīgi saliekta, – kaitē gan miesai, gan prātam, gan cilvēciskajām attiecībām. Par ilgtermiņa fiziskajām, sociālajām un intelektuālajām sekām daudziem pietrūkst laika domāt.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Kā ziņo The New York Times, daudzi vadošo interneta kompāniju darbinieki sākuši pilnībā aizliegt pieeju viedtālruņiem, planšetdatoriem, parastajiem datoriem. Atēna Čavarija, Facebook darbiniece, laikrakstam atzīst: „Esmu pārliecināta, ka telefonos dzīvo pats nelabais un nodara milzīgu postu mūsu bērniem!”",
+  "KLASE": 9,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "” Daudzām turīgo bērnu auklēm jāparaksta līgums, ka bērnu klātbūtnē nelietos mobilos telefonus un neļaus to darīt arī viņiem. Kaimiņi nobildē pieaugušos, kuri bērnu klātbūtnē iegrimuši telefonos, un fotogrāfijas ieliek čatu grupās ar jautājumu – vai tā ir tava auklīte? Kamēr telefons bija pie saites, tikmēr cilvēks bija brīvs.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Amerikā vienlaikus parādās digitālā plaisa. Nabadzīgākās skolas dižojas ar elektroniskām ierīcēm, kamēr bagātnieku skolās tās stingri ierobežo. OECD ir veicis pētījumu, kurā apliecina, ka datoru izmantošana klasēs neuzlabo skolēnu sekmes. Silīcija ielejas vecāki acīmredzot vairāk uzticas OECD nekā savu uzņēmumu mārketinga nodaļām, kuras runā par viedierīču pozitīvo ietekmi uz bērnu zināšanām un prasmēm.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Pirms divsimt gadiem, kad industriālā revolūcija bija sākusi tricināt sabiedrības pamatus, Mērija Šellija publicēja vienu no pasaules slavenākajiem romāniem Frankenšteins – par cilvēku, kurš ar jauno tehnoloģiju palīdzību izveido monstru, kas vēršas pret savu radītāju. Ja M. Šellija būtu dzīva, viņa varētu uzrakstīt jaunu romānu Frankenbook – par tehnoloģijām, kuras sola zināšanas, draugus, taču daudziem sniedz izniekotu laiku, viltus ziņas un atsvešinātību.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Gadžeti – mazas mehāniskas vai elektroniskas ierīces ar kādu noteiktu funkciju. Cilvēku sugas evolūcija nav atdalāma no darbarīkiem, ar to mēs atšķiramies no dzīvniekiem, jo protam tos izmantot. Laika gaitā iegūstam jaunus darbarīkus.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Mēs vairs neatceramies par tikšanos, ja neesam to ierakstījuši telefona kalendārā. Šo funkciju smadzenes ir novirzījušas konkrētajam darbarīkam. Mēs sāpīgi reaģējam, kad telefons tiek pazaudēts vai aizmirsts mājās, bez tā jūtamies gluži kā ar sasietām rokām.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Ņemot vērā smadzeņu attīstības posmus, var teikt, ka bērnam līdz 2 gadu vecumam vispār nevajadzētu dot ekrānierīces. Zinātniski pierādīts, ka bērns šādā vecumā neuztver ekrāna saturu, jo viņa smadzenes vēl nav nobriedušas. Vienīgais izņēmums būtu īslaicīgai bērna nomierināšanai, piemēram, bērnam dodoties pie stomatologa, lai novērstu uzmanību un varētu veikt nepieciešamās manipulācijas.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Tikai divgadnieks sāk saprast ekrānā notiekošo, tad kvalitatīvs saturs var veicināt valodas attīstību, turklāt tas būtu jādara kopā ar vecākiem. Bērni, kas līdz 5 gadu vecumam intensīvi skatās ekrānā, vēlāk sāk runāt, viņiem ir grūtības ar uzmanības koncentrēšanu, ar atmiņu. Stāsts par pusaudžiem un viedierīcēm ir pavisam cits, jo tur prasmīga gadžetu izmantošana ļauj piekļūt informācijai, kas noder izglītības procesā, var sekmēt pozitīvas identitātes veidošanos, attīstīt empātiju, toleranci un cieņu pret atšķirīgo.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Diemžēl intensīva darbošanās ar ekrānierīcēm samazina vecāku un bērna kopā būšanu. Protams, nedrīkst krist ne panikā, ne dzīvot vienā mierā. Mēs vairs nevaram atbrīvoties no ekrānierīcēm, jo tā ir daļa no mūsu dzīves. Psihologi iesaka – ģimenei vajadzētu nodrošināt laiku, kas ir pilnīgi brīvs no jebkādiem ekrāniem.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Jāpiedāvā spēlēšanās svaigā gaisā, jādara kaut kas radošs, jāveic eksperimenti. Tas attīsta bērna domāšanas spējas, iztēli, bet arī vecākiem šajā procesā jāiesaistās. Arī garlaikoties nav slikti, jo laiks, kas pavadīts garlaikojoties, veicina iztēles attīstību. Un, ja bērnam nav interesanti, viņš sāks kaut ko izdomāt un radīt. Bet ar ekrānierīci rokās garlaicīgi nav nekad!",
+  "KLASE": 9,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Proza ir mana labākā draudzene. Šais laikos tas neko daudz neizsaka, jo īsta draudzība nav augstā vērtē un tālab sastopama reti. Izplatītāks ir izdevīgums un paziņu simti vai tūkstoši kā svētās aprites mazās, zāļainās takas. Bet Proza ir īpašs draugs\/draudzene. Tu vari viņai stāstīt pilnīgi visu, bet viņa nenodos, neklačosies, neaprunās un nepīs intrigas. Viss paliks viņā. Tevis uzticēto jūs pa abām laiku pa laikam pārvērtīsiet tik gudri, ka šķitīs – tas ir stāsts par tevi, nevis mani.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Proza ir laba klausītāja, vari tarkšķēt kā par tuvāko zvaigznāju izmēriem, tā smaržu flakona dizainu. Gan par mātes kavalieru sejas izteiksmēm, gan savu garastāvokļu atkarību no mēness gaitas sevī un izplatījumā. Neko viņa neaizmirsīs. Kad tu pati jau būsi aizmirsusi, viņa izcels no tev šķietami nezināmas dzelmes acu priekšā, lai mēs pa abām tad spētu radīt to atmosfēru, to telpu, noskaņu un smaržu, kāda iespējama tikai starp mums.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Tomēr ir daži nežēlīgi nosacījumi attiecībās ar Prozu. Tu nekad nedrīksti viņai melot, un tu nedrīksti viņu atstāt novārtā. Proza nav nekāda draugaļa vai mīļākais, ar ko piedzīvot varavīkšņainu atklāsmju pārsātinātas nedēļas nogales, par ko sentimentālajā vecumā stāstīsi mazbērniem. Proza nav īslaicīgs sakars, tālab vienmēr smieklīga ir tās salīdzināšana ar dzeju, vienai uz otru pakāpjoties vai grūstoties uz pjedestāliem.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Proza necieš ārišķību [..] un dažādus efektus, tie ir viņas asinsritē, nevis uz ādas. Proza grib vienmēr būt tev klāt. Diendienā. Tiesa, viņa neiejaucas, kā mēdz mirkļu draudzenes vai draugi, iedomādamies izkārtot tavu likteni vai sadzīvi, sparīgi ņemot to savās nesavtīgajās rokās, bet aizmirstot pajautāt, kā tu patiesībā jūties.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Proza ir nemitīga klātbūtne bez aizgādnieciskuma, klātbūtne bez pretenzijām uz savu liktenīgo lomu, taču klātbūtne pat tavās attiecībās ar ikvienu citu cilvēku. Pat to, kuru iemīli, mīli, [..] iekāro. Viņa ir klāt, un tava personiskā dzīve vienmēr ir trijatā. Proza nepaģēr piesavināties tavas jūtu straumes sev, bet viņa tajās gan peldēs, gan bangos līdzi.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Arī tad, kad tev ir neizciešami smagi, kad asiņo tavs egoisms un patmīla, viņa arī ir turpat. Vienaldzīgāka par nāvi. Viņa nemierina, viņa ir auksta un nepazīst līdzjūtību, ja vien tā neesi tu pati, kas putro līdzjūtību ar spēju uzklausīt un klausīties.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "ausīt un klausīties. Protams, tu vari viņu triekt ratā, ja nevēlies dzīvot kopā ar kādu, kas pat nav tava ēna, bet neierāmēts, šķautņains un tevī pašā iekšupvērsts spogulis. Ir iespējams izvēlēties, ir iespējams atsacīties. Bet nekad nebūs iespējams aizmirst kopā dzīvoto laiku, mūsu divata radīto dimensiju, kam nav analoga un imitācijas iespēju.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "ju. Nianses un formu arhitektūra, kas paslīd garām lasītājam, nozīmes un šifri, ko neuzpazīst kritiķi, – to visu Proza iesūc sevī, labsajūtā ņurdīgi murrādama. Jo biezākā klājienā, jo viņas gandarījums ir dziļāks, uzņemot sevī tavas dvēseles un apziņas sarežģītos kontrapunkta trombus. Ne viss, kas Prozai uzticēts, nonāks citu acīs. Viņa netic daiļiem jūtuļošanās būrumiem un idilliskām vārdu krellēm, kas grab pašas savā meldiņā, tās viņai pat derdzas, tad viņa aizsūtīs tevi paciemoties pie savām attālajām, bet ļoti viesmīlīgajām māsīcām – Psiholoģijas, Psihoterapijas un Grafomānijas.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Tomēr proza ir augstsirdīga un sevī vien skumji nopūtīsies, ja tu uzvilksi viņas, ne savu kleitu un spridzēsi ar viņas diadēmu kā savējo publiskās pasākšanās un ceremonijās. Par spīti šodienas realitātēm, Proza vienlīdz necieš kā manierību, tā prastumu. Jo viņai vispār nepiemīt virspuse. Ja kritiķi tādu atrod, visticamāk, viņi kaut ko citu sauc Prozas vārdā.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Proza ļauj dzīvot sarežģītu apziņas dzīvi. Tā nav dota kā dāvana vai tāls ceļojums, tā ar viņu ir līdzradāma, kaut bez parauga tā saucamajā reālajā dzīvē. Manā un Prozas kopējā pasaulē ir neizsakāmi skaisti, taču neizsacīta šī pasaule zūd. To Proza pieprasa. Pretējā gadījumā tu attopies pie avīžraksta tukšā istabā, kurā tavas draudzenes it kā nekad nebūtu bijis. Un tomēr viņa ir, vien tavu vājuma brīdi taktiski pieņēmusi zināšanai bez moralizējošiem komentāriem.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Par savu labāko draudzeni varu stāstīt daudz un gari, taču tas šolaiku racionālajam cilvēkam nevar lietišķi noderēt. Jo mana Proza ir tikai mana Proza. Un jebkuram otram, kurš pieņem iepriekšminētos apdraudējumus, būs pašam sava. Un – viena vienīgā. Jautājums – vai ir vērts – ir gandrīz nepieklājīgi intīms. Ja dzīvē vispār pastāv garantijas, tad man šķiet, ka ar Prozu kopā nevar dzīvi nodzīvot Pozā. Domāju, ka šim laikmetam tā ir dievišķa greznība.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Rakstnieces Ingas Žoludes trešā grāmata, romāns „Sarkanie bērni”, ir mecenāta Raimonda Gerkena un Latvijas Rakstnieku savienības 2011. gada latviešu oriģinālo romānu konkursa laureāts kategorijā „Labākais prozas darbs”.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Un kāda tavā uztverē ir reālā pasaule – tā, kurā dzīvo tu pati? Pasaule, kurā dzīvoju es kā fiziska persona, ir nošķirta no manis rakstītā romāna pasaules. Dzīve un literatūra ir divas pasaules. Man, protams, bez vienas nebūtu otras un bez otrās nebūtu pirmās.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Nenoliedzami, darba rakstīšanas brīdī mana būtība atrodas romāna pasaules radīšanas, iztēlošanās, apdzīvošanas režīmā, un pasaule, kurā eksistē mans ķermenis, aizpeld otrajā plānā, mani tirda nemiers un kaislība atgriezties pie rakstāmās pasaules, kamēr tā nav piepildīta. Bet, ja jautājums ir, vai es savos darbos aprakstu savu reālo dzīvi, tad atbilde ir – nē, vismaz apzināti nē.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Vai vari pastāstīt, kā tieši tu panāc, lai abām šīm tik atsevišķajām pasaulēm būtu katrai sava vieta? Lai tās nemaisītos viena otrai pa kājām, nesajauktos? Vieglāk ir panākt, lai dzīve neiejauktos literatūrā, piedomājot nerakstīt par sevi. Bet šīs robežas ir plūstošas, ir epizodes un emocijas, kuras es iestrādāju savos darbos. Jebkurš vērojums un refleksija ir izejmateriāls, un es tos apzināti vācu.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Bet radāmā pasaule dzīvē iejaucas daudz vairāk un spēcīgāk – man taču nav jāstāsta, ka tad, kad intensīvi rakstu, aizmirstu paēst, laiks paiet un ilgstoši nepieceļos no rakstāmgalda, slikti guļu, jo arī miegā rakstīšana nebeidzas, nespēju izsekot dzīvu cilvēku sarunām ar mani, jo domās dzīvoju savu varoņu dzīves, man zūd empātija pret dzīviem cilvēkiem, es kļūstu nervoza, ja nevaru rakstīt tieši tajā brīdī, es runāju un domāju citādi, jo esmu Tur iekšā. Bet es jau zinu, ka tas tā ir, un nepretojos.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "epretojos. Ir lietas, ko es netiecos pieredzēt uz savas ādas, jo esmu par tām jau rakstījusi, es tās jau esmu izdzīvojusi bez sava fiziskā ķermeņa iesaistīšanas, un man par tām vairs nav intereses. Es jau aptuveni apzinos savas iztēles iespējas un apzinos, ka es tās varu paplašināt, ja vēlos.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Piemēram, kad cilvēki jautā par manu darbu varoņiem un situācijām, viņi jau nenošķir mani no fikcionālās pasaules – daudziem šķiet, ka tās ir manas domas, mani pārdzīvojumi, mana pieredze, nevis tēlu, lai gan manas vērtības un uzskati var atšķirties no manis radīto tēlu uzskatiem, vārdiem, rīcības. Dažreiz es šajā spēlē arī iesaistos un ļaujos tikt identificēta ar saviem tēliem, vēstītājiem utt.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Cik svarīgi tev ir tas, lai lasītāji saprastu to ideju, ko esi iekļāvusi savos darbos? Es domāju, ka lasītājs ir tas, kurš rada tekstu. Proti, katrs izlasīs kaut ko savu, jo mūs uzrunā tas, kur mēs varam atrast saikni ar sevi, ar savu dzīvi, ar realitāti, vai arī – tieši pretēji – tas, kas mums ir jauns, pārsteidzošs, varbūt pat pilnīgi pretējs, tas iekrīt acīs un par to nākas domāt. Arī vārdi un valoda ir cieši saistīti ar pieredzi, tāpēc šķietami viennozīmīgi un zināmi vārdi katram nozīmēs kaut ko nedaudz citu.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Es domāju, ka arī manus tekstus var izlasīt daudz dažādos veidos, un man tas patīk, tas mani priecē. Protams, šiem dažādajiem lasījumiem vajadzētu būt saistītiem ar tekstu un sekot veselajam saprātam – tādā nozīmē, ka nevar piesiet tekstam to, kā tur nav, bet ko lasītājs par visām varēm tur vēlas saskatīt vai iztulkot. Katrā ziņā es neuzstāju, ka visiem būtu jāizlasa mans teksts vienā vienīgajā veidā – tā, kā es to uzskatu par vajadzīgu, iespējamu.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Domāju, ka arī rakstnieks pats nespēj līdz galam prognozēt sava teksta saprašanas, interpretācijas, „tulkošanas” veidus, tieši tā paša iemesla dēļ – rakstnieks nespēj līdz galam aptvert valodas potenciālu, sevišķi tādā sarežģītā sistēmā, kāda ir teksts, kur viss ir savā starpā saistīts, visas šīs asociācijas... kā vārdi un to apzīmētās parādības savā starpā saspēlējas, sevišķi, kad klāt nāk vēl individuālās pieredzes. Man vienmēr ir vairāk interesējusi daudznozīmība – var saprast tā šā un vēl kaut kā – tas piešķir šo dziļumu, kādu neredzamo dimensiju, ko lasītājs pats būvē, man vienmēr patīk atstāt vietu, kur lasītājam to būvēt. Taču tas nenozīmē, ka mani darbi nav pabeigti vai tajos kaut kā trūkst, es domāju, ka tieši tādam ir jābūt tekstam – tur ir jābūt brīvai vietai lasītājam.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2021\/2022"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Intars un Klāvs sēdējā uz vannas malas un aizrautīgi stāstīja, kā viņi meklējuši Dusmukuli. Maisiņš sašutis sāka savu stāstu: – Varu iedomāties. Bet... ja jūs zinātu, kas notika ar mani! Jūs neticēsiet, kur es nonācu. Tā bija īsta atkritumu sala, tikai nevis Klusajā okeānā, bet tepat Latvijā! Brāļi skolā par to mācījās. Viņi dabaszinību stundā bija dzirdējuši, ka Klusajā okeānā esot tāda atkritumu sala, kurā straumes sanes plastmasas atkritumus vienkopus.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Dusmukule turpināja stāstīt: – Mašīna pēc mašīnas, pilnas ar visādu drazu, brauc uz turieni – un gāž, un gāž ārā atkritumus. Tā kā fabrikā. Atbrauc mašīna ar atkritumiem, sargs paceļ barjeru, nosver. Kaut ko prasa, saka. Sākumā visu sagāž angārā, bet tur tāds tracis, dzirdēt neko nevar. Milzīgi kombaini rūc, šķiro tos savestos drazas kalnus.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Plastmasu – tur, stiklu – tur, metālu – tur. Viss netīrs, nelaba smaka. Kartupeļu mizas kopā ar pustukšiem jogurta traukiem. Tās taču ir drausmas! Kamēr maisiņš aizrautīgi dalījās iespaidos, abi brāļi jau prātā bija izdomājuši neskaitāmi daudz jautājumu. Pēkšņi Klāvs neizturēja un satraukti jautāja:",
+  "KLASE": 3,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "– Kur tas viss pēc tam paliek? Brāļu uzticamais draugs turpināja: – Kas tad to lai zina! Izskatās, ka turpat arī krājas milzīgos kalnos. Es tā pavirši uzmetu aci, man šķiet, ka tur drīz vairs atkritumiem nepietiks vietas. Klāvs saspringti domāja un skatījās uz maisiņu, līdz viņu sarunu pārtrauca puišu mamma. Brāļi devās uz virtuvi, lai paēstu vecāku sarūpēto launagu. Maltītes laikā zēni sāka stāstīt, ka viņiem skolotājs uzdevis veikt dabaszinību pētījumu.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Klāvs un Intars dedzīgi stāstīja, ka viņi nolēmuši pētīt, cik daudz atkritumu viņu ģimene saražo gada laikā. Tētis interesējās, kā šādu pētījumu vispār būtu iespējams veikt. Brāļi dedzīgi sāka stāstīt: – Neko nedrīkst mest ārā!",
+  "KLASE": 3,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Mēs krāsim, mazgāsim un šķirosim atkritumus. Vai jūs zinājāt, ka viens cilvēks saražo aptuveni 400 kilogramu drazu gadā? Un atkritumi nekur nepazūd! Jā, mašīna tos izved, bet tie visi krājas milzīgos kalnos. Mums jāizpēta, cik daudz atkritumu rodas mūsu ģimenē. Mamma, sastingusi ar tējas krūzi rokās, raudzījās uz dēliem un mēģināja iedomāties, cik daudz atkritumu maisu pagalmā varētu nozīmēt šis eksperiments.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Apmēram katru otro dienu ir jāiztukšo atkritumu spainis, tas nozīmē apmēram trīs maisi nedēļā. Tētis tikmēr uzdeva jautājumus, cenšoties noskaidrot, cik ilgi un kā tieši varētu notikt šis pētījums. Pēc brītiņa mamma centās dēlus pierunāt aprēķināt, cik atkritumu viņi varētu savākt, bet zēni nepiekrita un turpināja savu sakāmo:",
+  "KLASE": 3,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "– Ir jābūt precīziem. Mēs visu krāsim, šķirosim un noskaidrosim, cik kilogramu sanāk. Tas ir svarīgi! Visi tie milzīgie atkritumu kalni, kas bojā dabu, ūdeņus, gaisu. Dzīvnieki tos saēdas un iet bojā. Vai jūs zinājāt, ka 2050. gadā okeānā atkritumu būs tikpat daudz kā zivju?",
+  "KLASE": 3,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Ģimene vēl kādu brīdi turpināja diskusiju. Domas nebija vienprātīgas. Taču brāļi bija apņēmības pilni. Visbeidzot tētis noteica: – Visi eksperimenti ir nedaudz neprātīgi, bet rezultāti varētu būt pārsteigumu pilni. Pētīsim!",
+  "KLASE": 3,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Klāvam bija desmit gadi, bet Intaram – deviņi. Brāļi mācījās trešajā klasē. Viņi dzīvoja divstāvu koka mājā kopā ar mammu, tēti un labu draugu, kurš nu jau nedēļu bija pazudis. Brāļi to izmisīgi meklēja – puiši katru pēcpusdienu pēc skolas devās ārā un braukāja ar riteņiem līdz vēlam vakaram.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Tētis ar mammu sprieda, ka puikas trenējas riteņbraukšanas maratonam. Patiesībā Klāvs un Intars meklēja savu pazudušo draugu – plastmasas maisiņu. Ne jau kaut kādu parastu plastmasas maisiņu. Bet gan maisiņu vārdā Dusmukule!",
+  "KLASE": 3,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Pavisam nesen šis maisiņš pamatīgi pārbiedēja Klāvu, kad tas šļūca pāri tiltam tieši tajā brīdi, kad Klāvs kopā ar mammu devās mājup. Brāļi sākumā maisiņu noturēja par ezi, bet izrādījās – tas bija dzīvs maisiņš, kurš puišiem atklāja, ka viņš un visi citi maisiņi jūtas garlaikoti un aizvainoti, jo to mūžs ir īss un tie pārāk drīz nonāk atkritumos. Puiši nolēma izglābt maisiņu un parūpēties par viņu.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Brāļi un palaidnīgais maisiņš kļuva par nešķiramiem draugiem. Maisiņa nešpetnā rakstura dēļ puikas draugu nosauca par Dusmukuli. Tagad viņš bija pazudis un brāļi nepaguruši to meklēja. Kādu dienu Klāvs un Intars nolēma veikt izmeklēšanu un sastādīja plānu.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Viņi abi iegāja tumšajā šķūnītī. Tur stūrī stāvēja brāļu vecā tāfele ar krītiņiem. Klāvs ātri uz tās uzšņāpa: „Misija – atrast pazudušo draugu!” Brāļi prātoja un rakstīja, kas gan varētu būt noticis ar viņu uzticamo draugu. Zēni sprieda, ka, iespējams, maisiņu aizpūtis vējš, varbūt mamma viņu izmetusi ārā, bet varbūt tētis viņā ielicis sviestmaizi un paņēmis līdzi uz darbu. Katrai problēmai viņi rakstīja klāt risinājumu.",
+  "KLASE": 3,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Viss sākās pirms sešiem gadiem, kad avīzes galvenais redaktors man paziņoja: – Līse, esmu nolēmis tevi sūtīt sensācijas medībās. – Kolosāli! – es atteicu. – Cikos un kur man jābūt? – Ja izbrauksi šodien, tad, khē… – viņš galvā rēķināja, – pēc četrpadsmit dienām būsi tur! Ar pirkstu viņš iebakstīja pasaules kartē, milzīga tukša laukuma vidū.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "– Ā, – es teicu, – bet tas ir pasaules otrā galā. Es piebāzu degunu tuvāk kartei. Tukšs laukums, pilnīgi tukšs un tumšs. – Un kas tajā apvidū atrodas? – To neviens īsti nezina, – galvenais redaktors dedzīgi saberzēja rokas. – Kolosāli, – es centos izklausīties iepriecināta.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "– Tur ir biezi džungļi, kurus neviens vēl līdz galam tā īsti nav izpētījis, – viņš vēlreiz iebakstīja tumšajā laukumā. Kā tādā melnā vēdera dobumā. – Līse, tev bail? – Pfff, nemaz, – es mānījos. Kā parasti. Savā profesijā bez mānīšanās es tālu nebūtu tikusi, jo man vienmēr bija jādzen pēdas kādam, kurš meloja, blefoja un krāpās, un, lai viņus atmaskotu, man nācās krāpties labāk.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Es tikai nevarēju saprast, kas īsti man būtu meklējams tādā nekurienē – pašā džungļu vēderā. – Tur dzīvo viens tāds, khem, sauksim viņu par lietusmeža dīvaini, kurš sacēlis kājās visu pasauli. – Klāj vaļā. – Glābdamies no kara dzimtajā Latvijā, viņš aizkuģoja uz Venecuēlu. Un tur, dziļi džungļos, viņš atklāja pasaules augstāko ūdenskritumu – Anhelu.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "ņš atklāja pasaules augstāko ūdenskritumu – Anhelu. – Eņģeļa ūdenskritums, – es atminējos. – Tas ir ūdenskritums uz upes, kuru arī atklājis Laime un nosaucis kādas Latvijas upes vārdā – Rio Gauja. Gauja. Par to rakstīja visas lielākās avīzes un žurnāls National Geographic. Pasaules mēroga slavenība. Sāku spicēt ausis.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "– Pēc tam viņš kļuva par pirmo cilvēku pasaules vēsturē, kurš kājām uzkāpis Velna kalnā – cilvēkiem gadsimtiem ilgi pilnīgi nepieejamā plakankalnē ar stāvām, gludām sienām, – redaktors stāstīja un rādīja man Velna kalna fotogrāfiju. Tiešām neizskatījās, ka dzīva būtne, cenšoties tur uzrāpties, varētu joprojām palikt dzīva.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "– Blefo, – es apšaubīju. – Tikpat labi viņš varēja apgalvot, ka plikām rokām uzrāpies debesskrāpī. [..] – Bet tas nav svarīgākais, – viņš pavēstīja un ieturēja zīmīgu pauzi. – Visi raksta, ka tas cilvēks atradis prātam neaptveramus zelta kalnus. Runā, ka viņa bērni ar dimantiem rotaļājoties kā ar visparastākajiem lauku akmentiņiem.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Acumirklī migla izklīda un mans prāts noskaidrojās. Lūk, baumas par zeltu un dimantiem gan droši vien nebija dūmi bez uguns. Gan jau šim fantazētājam ir kas slēpjams. Varbūt tur, džungļu viducī, tālu no svešām acīm uzcelta pils, kur šī slavenība un viņa ģimene mīt pasakainā bagātībā. Ja patiesība nāks gaismā, sanāks elpu aizraujošs stāsts.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Mana iztēle tūliņ koši un sulīgi izkrāsoja karti, uz kuras slēpās tumšais lietusmežs, koki ar gaļīgām lapām, papagaiļi ar spilgti dzeltenām, sarkanām, zaļām un zilām spalvām, raibi jaguāri ar mīksti rozā degungaliem, daudzkrāsu orhidejas, karsta saule un caurspīdīgs kalna upju ūdens… Paradīze.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Biju gatava sēsties pirmajā lidmašīnā, lai dotos pāri Atlantijas okeānam pie džungļu bagātnieka. – Viņu sauc Aleksandrs Laime, – redaktors teica un pasniedza man papīra lapiņu. Tā bija telegramma – tādas agrāk sūtīja e-pastu vietā, un tās bija ātrākas par pasta vēstulēm. Telegrammu bija sūtījis pats džungļu bagātnieks. „Visi žurnālisti esmu atklājis kaut ko sensacionālu brauciet šurp pēc lietus Laime.”",
+  "KLASE": 6,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "– Atklājis kaut ko sensacionālu! – es atkārtoju. – Varbūt atradis pasaulē lielāko dimantu? Mans redaktors māja ar galvu. – Pēc lietus – tas droši vien nozīmē pēc lietus perioda. – Tad, kad upju krastos izskalojas visvairāk dimantu, – redaktors čukstēja. Es lasīju tālāk: – „P.S. Paķeriet līdzi 200 kg sāls.” Divsimt kilogramu sāls!? Telegrāfā būs kļūdījušies. Droši vien domāti divi kilogrami…",
+  "KLASE": 6,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Lai pievērstu sabiedrības uzmanību tam, ka bērni lasa interesantas un skaistas grāmatas latviešu valodā, tiek pasniegta Jāņa Baltvilka balva. Šo balvu bērnu literatūrā un grāmatu mākslā piešķir jau kopš 2004. gada. Savukārt kopš 2008. gada apbalvo arī vienu Baltijas jūras reģiona rakstnieku un viņa darba tulkotāju.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Balvas mērķis ir mudināt talantīgus rakstniekus un māksliniekus radīt grāmatas bērniem, kā arī rosināt bērnus un viņu vecākus izvēlēties augstvērtīgas grāmatas. Darbus apbalvo trīs nominācijās: darbs rakstniecībā bērniem, bērnu grāmatu ilustrēšana, un trešā balva tiek pasniegta vienam Eiropas valstu rakstniekam un viņa darba tulkotājam.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Balvu – porcelāna „Baltā Vilka” laiviņu – laureātiem veido māksliniece Inese Brants. Savā sapņu laiviņā sēž vilciņš un lasa grāmatu. Laureāti to saņem katru gadu 24. jūlijā, jo tad ir rakstnieka Jāņa Baltvilka dzimšanas diena. Balvas saņēmēji ir visiem zināmi latviešu rakstnieki. Tā pirmo balvu ieguva Māra Runguļa grāmata „Divdabis un Stulbcepure”.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Starp laureātiem ir arī Inese Zandere, Juris Zvirgzdiņš, Inga Gaile, Anete Melece, Kārlis Vērdiņš, Aivars Kļavis, Marts Pujāts u. c. Savukārt 2022. gadā par grāmatu „Laimes bērni” balvu ieguva Luīze Pastore. Kopš 2015. gada balvu skaits ir papildināts vēl ar vienu nomināciju – debija bērnu un jauniešu literatūrā. Balvu sponsorē uzņēmums „Latvijas Valsts meži”, un tās nosaukums ir „Jaunaudze”.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "2020. gadā šo balvu saņēma Viesturs Ķerus par stāstu „Meža meitene Maija”. Interesanti ir tas, ka autors no naudas balvas atteicās, jo neatbalsta „Latvijas Valsts mežu” izciršanas politiku. Viesturs Ķerus lūdza pasaudzēt kādu vecu meža stūri un nosaukt to Jāņa Baltvilka vārdā. Literatūrzinātniece Ilze Stikāne, kas jau daudzus gadus darbojas žūrijā, atzīst, ka visas lielākās balvas pasaulē piešķir, vadoties pēc pieaugušo vērtējuma, tomēr tas nav bērnu vērtējums. Bērnu viedokli redz Bērnu žūrijā, un mēdz būt gadījumi, kad abu vērtētāju grupu viedokļi atšķiras.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Ilze Stikāne norāda, ka bagātīgs ir grāmatu klāsts mazākajiem lasītājiem, bet ar pusaudžu literatūru ir sarežģītāk – katru gadu top tikai 2–3 izcili latviešu autoru darbi, un tas ir par maz. Uz jautājumu, kāpēc tā, literatūrzinātniece atbild, ka rakstīt pusaudžiem ir grūtāk, jo rakstniekam izjust pasauli ar pusaudžu dumpīgumu, lecīgumu un jūtīgumu nav vienkārši.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Pusaudžus piesaista grāmatas, kas atbild uz viņu jautājumiem, proti, dzīves jēga, izvēles un sava ceļa jautājumi. Ilze Stikāne atzīst, ka gribētu, lai rakstnieki vairāk pievērstos pusaudžu problemātikai. Apbalvošanas ceremonija ir īpašs notikums. Tajā ne tikai uzstājas rakstnieki ar savu jaunāko darbu lasījumiem, bet katru gadu muzikālu pirmatskaņojumu piedzīvo solodziesmas ar Jāņa Baltvilka dzeju.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Jāņa Baltvilka balvas pasniegšanu rīko Latvijas Bērnu un jaunatnes literatūras padome, kas no laureātu vidus nominē kandidātus prestižākajiem bērnu literatūras apbalvojumiem pasaulē – Hansa Kristiana Andersena balvai, Astridas Lindgrēnes piemiņas balvai un IBBY Goda sarakstam. Tādā veidā mūsu labākās bērnu grāmatas var iepazīt lielākajos grāmatu tirgos pasaulē un tās tiek iekļautas pasaules labāko bērnu grāmatu sarakstos „The White Ravens”.",
+  "KLASE": 6,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Pirms digitalizācijas laikmeta viena no vissvarīgākajām informācijas platformām bija drukātā prese. Viens no savulaik visietekmīgākajiem latviešu laikrakstiem bija „Jaunākās Ziņas”, kuru izdeva Emīlija un Antons Benjamiņi. Viņi gan kopā, gan katrs individuāli bija ekscentriskas personības, kas spilgti un paliekoši iezīmējušās Rīgas un Latvijas kultūras vēsturē.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Antons Benjamiņš dzimis 1860. gada 13. jūlijā. Droši var apgalvot, ka Antona Benjamiņa interešu un darbību loks bijis plašs. 1880. gadā Benjamiņš pabeidza Cimzes skolotāju semināru Valkā, pēc tam 20 gadus strādāja par pedagogu Rūjienā, Ogrē un Plāterē. Paralēli tam viņš bija gan kora, gan divu veikalu vadītājs Madlienā un Skrīveros. Bija precējies ar Madi Jurjāni.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Pēc veikalu bankrota un laulības šķiršanas Benjamiņš pārcēlās uz Rīgu, kur uzsāka reportiera un redaktora gaitas. Viņš strādāja gan vācu avīzē „Rigasche Rundschau”, gan laikrakstos „Mājas Viesis” un „Rīta Vēstnesis”",
+  "KLASE": 9,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "3. „Rīta Vēstnesi” sāka izdot 1910. gadā Haims Blankenšteins. Redakcijā kopā ar Antonu Benjamiņu darbojās arī Kārlis Skalbe, kurš avīzes satura veidošanai piesaistīja arī citus rakstniekus, piešķirot izdevumam „solīdu literāro nokrāsu”. Lai arī „Rīta Vēstnesī” netrūka nedz latviešu autoru vārdu, nedz viņu oriģināldarbu, sabiedrība avīzi iegādājās vien pieticīgos apjomos.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Benjamiņš par savu mērķi izvirzīja padarīt „Rīta Vēstnesi” par visjaunāko un vislētāk iegūstamo ziņu avotu, sašaurinot izdevuma tēmu spektru un piedāvājot lasītājam koncentrētu un kodolīgi formulētu informāciju. Sekojot šādai stratēģijai, izdevās palielināt avīzes tirāžu.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": " Sapratis, ka atrodas uz īstā ceļa, Benjamiņš pameta „Rīta Vēstneša” redakciju un 1911. gada\n8. decembrī kopā ar Emīliju Elku izdeva „Jaunāko Ziņu” pirmo numuru. Izdevumu ar rokas presi iespieda\n7000 eksemplāros gotu šriftā bez fotogrāfijām, tas nebija lielāks par divkāršu rakstāmpapīra loksni un\nmaksāja vienu kapeiku. Tieši šī iemesla dēļ „Jaunākās Ziņas” to sākotnējā attīstības posmā dēvēja arī par\nkapeikas avīzīti.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Emīlija Benjamiņa (pirms tam Elks) dzimusi 1881. gada 10. septembrī. Viņa bija ekscentriska, harismātiska un ietekmīga sieviete, un viņas publiskais tēls sabiedrības acīs allaž saglabājās cienījams. Emīlijas panākumi sniedzas tālu ārpus izdevējdarbības robežām – viņa darbojusies Starptautiskajā sieviešu savienībā, Paula Stradiņa izveidotajā Vēža apkarošanas biedrībā, bijusi Latviešu–zviedru biedrības valdes locekle, dibinājusi Rīgas Jūrmalas palīdzības un labierīcības biedrību, bijusi godabiedre vairākās sabiedriskajās, labdarības un sieviešu organizācijās.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "1932. gadā Emīlijai Benjamiņai piešķir ceturtās, bet 1937. gadā – trešās šķiras Triju Zvaigžņu ordeni par darbu latviešu un zviedru tautas kultūras tuvināšanā. 7. XIX un XX gadsimta mija atnesa pārmaiņas, un Emīlija Benjamiņa bija viena no pirmajām latviešu sievietēm, kas nepakļāvās sabiedrības patriarhālajām ieražām. Viņai bija raksturīgs viss, kas mūsdienās, visticamāk, izpelnītos stipras un neatkarīgas sievietes apzīmējumu.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": ". Vēl pirms pirmās īsās laulības ar dziedātāju Ernestu Elku-Elksnīti jaunā sieviete strādāja, pelnīja un sajūsminājās par teātri. Emīlija bija mācījusies grāmatvedību, darbojās reklāmas nozarē un rakstīja vācu un latviešu preses izdevumiem par latviešu teātri.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Ar Antonu Benjamiņu Emīlija satuvinājās Rīgas Jaunā teātra biedrībā, viņi viens otram bija izcili sarunu biedri un nepagurdami sprieda par aktuālo un vērtīgo literatūrā un teātrī. Tieši Emīlija ir bijusi tā, kas pierunāja Benjamiņu atstāt Blankenšteina izdoto „Rīta Vēstnesi” un kopā ar viņu uzsākt „Jaunāko Ziņu” darbību.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "1912. gada laikā avīzes tirāža tiek palielināta līdz pat 24 000 eksemplāru, tolaik tās centrā bija latviešu darba ļaužu problēmas, strādnieku dzīves apstākļi un tautas valodas tiesību aizstāvēšana. Krievu administrācijai šāda pieeja, protams, nepatika, un jau 1913. gadā „Jaunākās Ziņas” saņēma sodu 300 rubļu apmērā par rakstu, kurā tika atklāti darba apstākļi Heflingera fabrikā. Tuvojoties Pirmajam pasaules karam, cenzūras žņaugi kļuva ciešāki.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": ". „Jaunākās Ziņas” izdeva arī kara laikā. Tās iznāca katru dienu, septiņas dienas nedēļā, un sniedza lasītājiem savu korespondentu ziņas no karalauka. Tādējādi tika nodrošināts stabils statuss un nostiprināta jau tā spēcīgā uzticība tautas vidū.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Redakcijas darbinieks Kārlis Skalbe šo „Jaunāko Ziņu” periodu atminas šādi: „Rakstīju tikai tik daudz, cik man bija, ko sacīt. Kur pietrūka vārdu un domu, tur liku punktu. Avīzīte toreiz bija maza. Tā bija brīnišķīga tautas lapiņa, ko mūsu kareivji nēsāja aiz zābaka stulma līdzās koka karotei. Līdzās rupjas maizes gabalam tā atrada vietu katras bēgļu sievas azotē.”",
+  "KLASE": 9,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Jaunākās Ziņas” iznāca līdz pat 1940. gada 9. augustam, vienīgais pārtraukums laikraksta iznākšanā bija no 1917. gada 21. augusta līdz 1918. gada 15. novembrim. Pēc kara beigām „Jaunākās Ziņas” jau viennozīmīgi uzskatīja par ietekmīgāko dienas laikrakstu, un divdesmitajos gados Antonu Benjamiņu sāka dēvēt par Latvijas preses karali.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": ". Pēc 1922. gadā noslēgtās laulības arī Emīlijai Benjamiņai piedēvēja preses karalienes titulu. 1928. gadā Benjamiņi iegādājās Pfābu dzimtas krāšņo ēku tagadējā Krišjāņa Barona ielā 12. Ne velti to dēvēja par Pfābu un pēcāk – par Benjamiņu pili. Te Emīlija Benjamiņa izveidoja salonu, kurā uzstājās slaveni mākslinieki, par kuriem, protams, arī rakstīja „Jaunākajās Ziņās”. Izdevums bija ieņēmis stabilu vietu Rīgas kultūrvidē, un tajā publicēja arī kritiķa Ernesta Brusubārdas apskatus par dažādām izrādēm un operas uzvedumiem.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "To, cik lielu rezonansi šie apskati varēja izraisīt, pierādīja atgadījums ar dziedātāju Marisu Vētru. 1930. gada 3. oktobra „Jaunākajās Ziņās” parādījās raksts ar nosaukumu „Dziedonis bez pienākuma apziņas”, kurā tika skarbi kritizēta Vētras iepriekšējā vakara uzstāšanās operā. Dziedātājs uz to reaģēja atbilstoši savam uzvārdam, tas ir, vētraini, un iepļaukāja Brusubārdu, tādējādi zaudējot darbu operā.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "1924. gada 8. decembrī, tieši 13 gadus pēc pirmā „Jaunāko Ziņu” numura iznākšanas, redakcija laida klajā jauno laikrakstu „Atpūta”. Tas iznāca katru nedēļu un bija visai ģimenei paredzēts izdevums. „Atpūta” izcēlās arī ar labas kvalitātes fotoreprodukcijām un augstvērtīgu literāro saturu, par ko rūpējās tādi autori kā Jānis Akuraters, Jānis Ziemeļnieks, Anšlavs Eglītis, Vilis Lācis un Kārlis Skalbe.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "1939. gada 14. maijā Antons Benjamiņš devās aizsaulē, Emīlija turpināja izdevējdarbību vēl gadu pēc viņa nāves. 1941. gada 14. jūnijā Emīliju Benjamiņu represēja. Atrodoties izsūtījumā, viņa atteicās vergot un līdz ar to nesaņēma dienas pārtikas devu. Emīlija Benjamiņa nomira no bada un dizentērijas. Interesanti un vienlīdz baisi, ka šādu viņas likteņa pavērsienu bija pareģojis fotogrāfs un gaišreģis Eižens Finks.",
+  "KLASE": 9,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Eiropas 19. un 20. gadsimta mijas literatūras kontekstā priekšplānā varam izvirzīt J. Poruka daiļradei raksturīgo humānisma aizstāvību. J. Poruka proza jau ir salīdzināta ar Gija de Mopasāna un Antona Čehova prozu, tajā aktualizētas modernā laikmeta problēmas, par kurām rakstīja arī Moriss Māterlinks, Knuts Hamsuns un Francs Kafka, kuri nesaudzīgi attēloja cilvēka vientulību un pamestību, cilvēka atsvešināšanās izjūtu.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "J. Poruks akcentē to, kas jau bija aktuāls Eiropas modernās rakstniecības centrā: apjautu, ka modernā laikmeta cilvēks jaunajā ekonomiskajā realitātē ir spiests revidēt vispārcilvēciskās ētiskās vērtības, kas 19. gadsimtā sakņojās kristietībā, tās ētiskajās likumībās un cilvēkmīlestībā, un jaunā laikmeta cilvēkam jācenšas humānismu īstenot laikmeta prasībām atbilstīgās izpausmēs. J. Poruks par šī modernā laikmeta izcilāko rakstnieku uzskatīja naturālistu Emīlu Zolā, jo tas laikmeta zvērībā, viņaprāt, izgaismoja cilvēcību. Tās aizstāvēšana ir daudzu J. Poruka darbu būtiskākais motīvs.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Pārejas laikmetā uz 20. gadsimtu briesmu sajūtu Jānis Poruks rāda traģiskās izpausmēs tieši sadzīvē, cilvēku ikdienišķajās attiecībās, kam rakstniecība līdz 19. gadsimta vidum pievērsa maz uzmanības. Tā ir novitāte J. Poruka darbos, ko 1901. gadā viņš vispārinot atzīst: „Traģika ir un paliek vadošais motīvs cilvēka dzīvē",
+  "KLASE": 12,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Uz traģikas pamatojas visi augstākie centieni, visas cīņas [..], dzīve un viņš [cilvēks] pats nesaskan ar viņa centieniem un ideāliem. [..] Dzīves kaites, meli, ienaids, skaudība nav mazinājušās, bet kļuvušas pat vēl asākas.” Un par to viņš raksta lielākajā daļā savu darbu. J. Poruks uzsver, ka jaunajā laikmetā cilvēciskajās attiecībās sāk dominēt vienaldzība, atsvešinātība, materiālās intereses, egoisms. „Draugi, vai jūs neesat ievērojuši, kādus vaibstus ir pieņēmušas jūsu sejas?” J. Poruks jautā kādā stāstā.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Savu laikmetu rakstnieks pat nosaucis par „slimo pasauli”, jo tajā pārāk maz ir iejūtības un sirsnības. Viņš skaidri apzinājās, ka „jauna pasaule neradīsies, pirms cilvēks neuzsāks cīņu pats ar sevi” (tā J. Poruks 1901. gadā, bet Albērs Kamī 1947. gadā: „Ne jau pasaule jāatjauno, bet cilvēks.”)",
+  "KLASE": 12,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "J. Poruks oponēja sociālajiem utopistiem, tajā skaitā Aspazijai un Rainim. J. Poruks prasīja personiskas pašaudzināšanas, pašizaugsmes gribu, jo „cīņa pašam ar sevi ir cīņu augstākā pakāpe”. Un cīņu ar sevi J. Poruks redz kā labā un ļaunā cīņu pašā cilvēkā, kam jānotiek nemitīgi.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": ". Reālajā dzīvē pasīvie cietēji fiziski iet bojā līdzīgi J. Poruka viszināmākajam tēlam Cibiņam vai paliek tajā izmisuma un pazemojuma bedrē, kur viņus iemet jaunā laika negācijas. Taču J. Poruks ir pārliecināts, ka viņu dzīves principi ir nākamības cilvēcības tapšanas pamats.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": ". Šis stāsts nav tikai par klusā, pabailīgā un tomēr arī uz protestu spējīgā Cibiņa likumsakarīgo bojāeju – galvenokārt tas ir līdzcilvēkus apsūdzošs darbs, jo Cibiņš nenosalst tikai Buņģa agresivitātes dēļ. Cibiņš iet bojā tāpēc, ka viņam visapkārt valda cietsirdība. [..]",
+  "KLASE": 12,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": ". Ko J. Poruks liek pretī sava laika dehumanizācijai un aprobežotībai? Pārliecību, ka arī jaunajā laikmetā galvenajai cilvēka pašizpausmei jābūt mīlestībai. Un ka jaunā laikmeta mīlestības iemiesotājs ir aktīvais un tikumiski godīgais cilvēks.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "7. J. Poruka lielais daiļrades motīvs un mākslinieka programma būtībā ir vienkārša un humānistiska šī vārda viscildenākajā nozīmē – ieskatieties empātiskāk cilvēku ciešanās un sāpēs, esiet saprotošāki, nepazemojiet viņus pat tad, ja viņus nesaprotat!",
+  "KLASE": 12,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Mūsdienu cilvēks J. Poruku sauks par utopistu un viņa alkas redzēt cilvēku empātisku arī modernajā laikmetā – par neauglīgu sapņošanu, taču šajā „utopismā” redzams J. Poruka humānisms. Viņš zināja, ka iejūtība un līdzjūtība izrotā cilvēku. 9. Vai mēs, 21. gadsimtā dzīvojošie, esam gatavi pieņemt J. Poruku?",
+  "KLASE": 12,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Cilvēki apskauž nemirstīgos dievus, un dievi nāk pie cilvēkiem, lai plūktu laimes un sāpju puķi, jo laime un sāpes ir tikai cilvēkiem. Upmalā netālu no ķēniņa pils reiz atrada mazu meitenīti. Varbūt viņu bij atnesis varenais vējš, kas, sagrābis savā klēpī miglaino pavasara nakti, uzlauza ledu, atrāva vaļā upes un atvēra debesīm logus. Bērns bij satīts pelēkā lakatā, un viņam blakus bij nolikta līka un kreveļaina kādas nezināmas puķes sakne.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Bērnu paņēma pils vārtu sardze un sakni iestādīja mazā māla podā. „Varbūt tā būs viņas laimes puķe,” tā klusām pie sevis domāja. Mazā bij ļoti skaista, tikai viņas kājas bij it kā neizveidotas un līkas. Tāpēc viņa nemīlēja staigāt, tikai skatīties. Atspiedusies uz rokas, viņa caurām dienām sēdēja pie vārtu sarga lodziņa, un visi apbrīnoja viņas maigo, balto seju un lielās, skumjās acis. Kas gāja garām rītā, pusdienā vai vakarā, tas arvienu viņu tā redzēja. Viņa bija kā balts ūdens zieds, kurš guļ uz līmeņa un nekad nemaina savu vietu.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Viņa negāja, kur bija ļaudis, jo kaunējās no savām kājām. Tikai vecais pils dārznieks viņu mīlēja. Viņa dārzā bij daudz līku un dīvaini kroplu koku, tie bija tie, kas viskrāšņāk ziedēja. Viņš bija laimīgs, kad mazā, turēdamās viņam pie rokas, ar savām strupām un līkām kājiņām staigāja viņam blakus pa dārzu. Viņš mīlēja to ar žēlumu.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Laimes puķe auga gausi, un meitene jau bija liela, kad tā sāka zarot. Viņai bij augstas krūtis un mazas smaidošas rokas. Tāpat kā arvienu, viņa vēl klusi raudzījās ārā no savas šaurās pasaules pa mazo vārtu sarga lodziņu. Cik vareni ir vecie koki vārtu priekšā, cik augstu iet mākoņi un cik skaists ir jaunais princis!",
+  "KLASE": 12,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Kad viņš gāja garām, viņas seja kļuva vēl baltāka un viņas krūtīs lēni spiedās iekšā it kā saldi asmeņi. Un vienā naktī bij noticis brīnums. Bij uzziedējusi viņas laimes puķe ar degoši sarkanu ziedu. Kad nāca prinča dzimšanas diena un visa zeme posās uz svētkiem, arī mazā vārtu sarga meitene gribēja ko cēlu padarīt.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Viņa paņēma savu sarkano puķi un gāja kā tālā miglā, nemanīdama savu kāju. Viņa gribēja nolikt savu ziedu augšā uz pils trepēm, kur marmora vāzēs stāvēja puķes. Viņa nesa to kā liesmu savās paceltās rokās. Bet pie beidzamām kāpnēm viņa paklupa, un atsedzās viņas kroplās kājas. Tai brīdī durvīs parādījās princis savu galma ļaužu vidū. Viņš smējās, un visi smējās.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Meitene apsedza seju rokām un vaidēdama kāpa lejā. Viņa ielīda savā vārtu sarga mājiņā, bet tā viņai nelikās diezgan tumša un zema. Viņa nokāpa pagrabā. Viņas sāpes bij lielas, bet viņas krūtīs bij degošs izsalkums, viņai gribējās vēl rūgtāku sāpju. Viņa iedzēra nāves zāles.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2022\/2023"
+ },
+ {
+  "TEKSTA_FRAGMENTS": "Tā viņai bij labi. Tā nokrita uz akmens klona un kunkstēja ar sakostiem zobiem. Tad, noreibusi no sāpēm, viņa piecēlās un izgāja ārā naktī. Tā ielēca upē un kļuva par ūdens meitu, kas viņa varbūt kādreiz jau bija bijusi. Tur, vēsā dziļumā, bāli zied saules puķe un mēness puķe. Bet tur nezied sarkanā puķe, jo tur nepazīst sāpju un prieka.",
+  "KLASE": 12,
+  "MACIBU_GADS": "2022\/2023"
+ }
+]
+}


### PR DESCRIPTION
Pievienotā datu kopa:
* VISC_LATV centralizēto latviešu valodas eksāmenu lasāmās un klausāmās daļas teksta fragmenti (katrā json objektā sakopoti 2-4 teikumi) un to klasifikācija pēc klašu līmeņiem un mācību gadiem, kuros šie fragmenti bija izmantoti.

Datu kopas statistika un darba piemērs ir aplūkojams [šeit](https://github.com/bezgaliba/lv-complexity/blob/main/LV_Complexity_LogRegression_Model.ipynb).